### PR TITLE
Fix OpenMP race conditions in surroundingRectangle

### DIFF
--- a/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
+++ b/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
@@ -59,7 +59,8 @@ struct Configuration {
 
 struct SurroundingRectangle {
     std::vector<int> parts;
-    std::vector<bool> is_ghost;
+    std::vector<int> is_ghost;
+    // WARNING vector<bool> is not thread-safe, don't assign in parallel region
     std::vector<bool> is_node;
     int size;
     int nx, ny;
@@ -76,6 +77,7 @@ struct SurroundingRectangle {
         ATLAS_TRACE();
         OrcaGrid orca{grid};
         int mypart     = cfg.mypart;
+        int nparts     = cfg.nparts;
         int nx_glb     = orca.nx();
         int ny_glb     = orca.ny();
         int ny_halo    = ny_glb + orca.haloNorth();
@@ -103,23 +105,32 @@ struct SurroundingRectangle {
 
         {
             ATLAS_TRACE( "bounds" );
-            std::vector<int> nb_nodes_owned_TP( atlas_omp_get_max_threads(), 0 );
             atlas_omp_parallel {
-                const size_t tid = atlas_omp_get_thread_num();
+                int ix_min_TP = ix_min;
+                int ix_max_TP = ix_max;
+                int iy_min_TP = iy_min;
+                int iy_max_TP = iy_max;
+                int nb_nodes_owned_TP = 0;
                 atlas_omp_for( idx_t iy = iy_glb_min; iy <= iy_glb_max; iy++ ) {
                     for ( idx_t ix = ix_glb_min; ix <= ix_glb_max; ix++ ) {
                         int p = partition( ix, iy );
                         if ( p == mypart ) {
-                            ix_min = std::min<idx_t>( ix_min, ix );
-                            ix_max = std::max<idx_t>( ix_max, ix );
-                            iy_min = std::min<idx_t>( iy_min, iy );
-                            iy_max = std::max<idx_t>( iy_max, iy );
-                            nb_nodes_owned_TP[tid]++;
+                            ix_min_TP = std::min<idx_t>( ix_min_TP, ix );
+                            ix_max_TP = std::max<idx_t>( ix_max_TP, ix );
+                            iy_min_TP = std::min<idx_t>( iy_min_TP, iy );
+                            iy_max_TP = std::max<idx_t>( iy_max_TP, iy );
+                            nb_nodes_owned_TP++;
                         }
                     }
                 }
+                atlas_omp_critical {
+                    nb_nodes_owned += nb_nodes_owned_TP;
+                    ix_min = std::min<int>( ix_min_TP, ix_min);
+                    ix_max = std::max<int>( ix_max_TP, ix_max);
+                    iy_min = std::min<int>( iy_min_TP, iy_min);
+                    iy_max = std::max<int>( iy_max_TP, iy_max);
+                }
             }
-            nb_nodes_owned = std::accumulate( nb_nodes_owned_TP.begin(), nb_nodes_owned_TP.end(), 0 );
         }
 
         // add one row/column for ghost nodes (which include periodicity points)
@@ -153,6 +164,20 @@ struct SurroundingRectangle {
                         is_ghost.at( ii ) = ( parts.at( ii ) != mypart );
                     }
                 }
+            }
+            if (nparts == 1) {
+              ATLAS_ASSERT(
+                std::all_of(parts.begin(), parts.end(), [](int i){ return i == 0;}));
+              std::ostringstream strm;
+              strm << "how is this possible. is_ghost count true: "
+                   << std::count(is_ghost.begin(), is_ghost.end(), true)
+                   << " false: "
+                   << std::count(is_ghost.begin(), is_ghost.end(), false)
+                   << " iy_min: " << iy_min;
+              ATLAS_TRACE(strm.str());
+              bool no_ghost_nodes_when_nparts_1 =
+                std::none_of(is_ghost.begin(), is_ghost.end(), [](bool b){ return b;});
+              ATLAS_ASSERT(no_ghost_nodes_when_nparts_1);
             }
         }
         // determine number of cells and number of nodes

--- a/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
+++ b/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
@@ -165,20 +165,6 @@ struct SurroundingRectangle {
                     }
                 }
             }
-            if (nparts == 1) {
-              ATLAS_ASSERT(
-                std::all_of(parts.begin(), parts.end(), [](int i){ return i == 0;}));
-              std::ostringstream strm;
-              strm << "how is this possible. is_ghost count true: "
-                   << std::count(is_ghost.begin(), is_ghost.end(), true)
-                   << " false: "
-                   << std::count(is_ghost.begin(), is_ghost.end(), false)
-                   << " iy_min: " << iy_min;
-              ATLAS_TRACE(strm.str());
-              bool no_ghost_nodes_when_nparts_1 =
-                std::none_of(is_ghost.begin(), is_ghost.end(), [](bool b){ return b;});
-              ATLAS_ASSERT(no_ghost_nodes_when_nparts_1);
-            }
         }
         // determine number of cells and number of nodes
         {  // Compute SR.is_node


### PR DESCRIPTION
I have experienced some race conditions when `OMP_NUM_THREADS != 1`. This causes some ASSERT statements to fail some of the time in the code, This was a little tricky to debug because the asserts triggered were further down the code.

I have attempted to add an extra ASSERT for when there is only one partition. I know for now we can only run the plugin in this configuration, and the performance hit of this check might be bad - is there a debug mode or something where I can add this check? Please help me out with that bit!

The first race condition is caused by multiple threads attempting to update variables like `ix_min` simulataneously. I have made these variables thread-private and then aggregated them in a critical section after the loop to remove the race and avoid false sharing.

The second race condition is caused by writing to a vector<bool>. Unfortunately this container is not thread safe (it is doing some fancy bit setting on integers I believe). See this [stack overflow answer](https://stackoverflow.com/a/39037606).

Testing
-------

I can only reproduce this for a sufficiently large problem on multiple processors, and even then it is intermittent, so I wasn't sure quite how to write a unit test to cover it! Advice on this would be good.

I have tested this by running on my machine with 4 processors and running an interpolation problem using this experimental interpolation executable I have been fiddling with ([maera](https://github.com/twsearle/maera).  I have also reproduced the issue in [orca-jedi](https://github.com/MetOffice/orca-jedi) (a Met Office internal repo as part of Next Generation Observation Processing). 10 runs are usually enough to reproduce the problem.

