### PR TITLE
fix: remove normalisation of longitude

### DIFF
--- a/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
+++ b/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
@@ -422,14 +422,15 @@ void OrcaMeshGenerator::generate( const Grid& grid, const grid::Distribution& di
 
                     // normal calculation
                     orca.xy( ix_glb, iy_glb, _xy );
-                    normalise( _xy );
-
-                    nodes.xy( inode, LON ) = _xy[LON];
-                    nodes.xy( inode, LAT ) = _xy[LAT];
 
                     // geographic coordinates by using projection
                     nodes.lonlat( inode, LON ) = _xy[LON];
                     nodes.lonlat( inode, LAT ) = _xy[LAT];
+
+                    normalise( _xy );
+
+                    nodes.xy( inode, LON ) = _xy[LON];
+                    nodes.xy( inode, LAT ) = _xy[LAT];
 
                     // part and remote_idx
                     nodes.part( inode )           = SR.parts[ii];

--- a/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
+++ b/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
@@ -422,15 +422,14 @@ void OrcaMeshGenerator::generate( const Grid& grid, const grid::Distribution& di
 
                     // normal calculation
                     orca.xy( ix_glb, iy_glb, _xy );
-
-                    // geographic coordinates by using projection
-                    nodes.lonlat( inode, LON ) = _xy[LON];
-                    nodes.lonlat( inode, LAT ) = _xy[LAT];
-
                     normalise( _xy );
 
                     nodes.xy( inode, LON ) = _xy[LON];
                     nodes.xy( inode, LAT ) = _xy[LAT];
+
+                    // geographic coordinates by using projection
+                    nodes.lonlat( inode, LON ) = _xy[LON];
+                    nodes.lonlat( inode, LAT ) = _xy[LAT];
 
                     // part and remote_idx
                     nodes.part( inode )           = SR.parts[ii];

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -32,3 +32,9 @@ ecbuild_add_test( TARGET  atlas_test_orca_valid_elements
                   LIBS    atlas-orca
                   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
                   CONDITION eckit_HAVE_LZ4 )
+
+ecbuild_add_test( TARGET atlas_test_orca_interpolation_bil
+                  SOURCES   test_orca_interpolation_bil.cc
+                  LIBS      atlas
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT} )
+

--- a/src/tests/test_orca_interpolation_bil.cc
+++ b/src/tests/test_orca_interpolation_bil.cc
@@ -1,0 +1,149 @@
+/*
+ * (C) Crown Copyright 2022 Met Office
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#include <cmath>
+
+#include "eckit/types/FloatCompare.h"
+
+#include "atlas/array.h"
+#include "atlas/functionspace.h"
+#include "atlas/functionspace/PointCloud.h"
+#include "atlas/grid.h"
+#include "atlas/interpolation.h"
+#include "atlas/mesh.h"
+#include "atlas/meshgenerator.h"
+#include "atlas/util/CoordinateEnums.h"
+#include "atlas/field/MissingValue.h"
+
+#include "tests/AtlasTestEnvironment.h"
+
+using namespace eckit;
+using namespace atlas::functionspace;
+using namespace atlas::util;
+
+namespace atlas {
+namespace test {
+
+//-----------------------------------------------------------------------------
+//
+
+CASE("test_interpolation_points_to_ORCA2_bilinear_remapping") {
+    Grid grid("ORCA2_T");
+    Mesh mesh(grid);
+    NodeColumns fs(mesh);
+
+    auto func = [](double x) -> double { return std::sin(x * M_PI / 180.); };
+
+    SECTION("at the equator, after seam") {
+        PointCloud pointcloud({{80., 0.},
+                               {90., 0.},
+                               {100., 0.},
+                               {110., 0.},
+                               {120., 0.},
+                               {130., 0.},
+                               {140., 0.},
+                               {150., 0.},
+                               {160., 0.}});
+
+        Interpolation interpolation(option::type("bilinear-remapping") | util::Config("non_linear", "missing-if-all-missing"), fs, pointcloud);
+
+        Field field_source = fs.createField<double>(option::name("source"));
+        field_source.metadata().set("missing_value", -3278.0);
+        field_source.metadata().set("missing_value_type", "approximately-equals");
+        field_source.metadata().set("missing_value_epsilon", 1e-6);
+        Field field_target("target", array::make_datatype<double>(), array::make_shape(pointcloud.size()));
+        field_target.metadata().set("missing_value", -3278.0);
+        field_target.metadata().set("missing_value_type", "approximately-equals");
+        field_target.metadata().set("missing_value_epsilon", 1e-6);
+
+        auto lonlat = array::make_view<double, 2>(fs.nodes().lonlat());
+        auto source = array::make_view<double, 1>(field_source);
+        for (idx_t j = 0; j < fs.nodes().size(); ++j) {
+            source(j) = func(lonlat(j, LON));
+        }
+
+        interpolation.execute(field_source, field_target);
+
+        auto target = array::make_view<double, 1>(field_target);
+
+        auto pc_view = array::make_view<double, 2>(pointcloud.lonlat());
+        std::vector<double> check;
+        for (int i = 0; i < pc_view.size(); ++i) {
+            check.push_back(func(pc_view(i, 0)));
+        }
+
+        atlas::field::MissingValue mv(field_target);
+        std::vector<bool> missing_vals(pointcloud.size(), true);
+
+        for (std::size_t j=0; j < target.size(); ++j) {
+          missing_vals[j] = mv(target(j));
+        }
+
+        for (idx_t j = 0; j < pointcloud.size(); ++j) {
+            static double interpolation_tolerance = 1.e-4;
+            char b = missing_vals[j] ? 'T' : 'F';
+            Log::info() << target(j) << "  " << check[j] << " " << b << std::endl;
+            EXPECT(eckit::types::is_approximately_equal(target(j), check[j], interpolation_tolerance));
+            EXPECT(!missing_vals[j]);
+        }
+    }
+    SECTION("at the equator, before seam") {
+        PointCloud pointcloud(
+            {{00., 0.}, {10., 0.}, {20., 0.}, {30., 0.}, {40., 0.}, {50., 0.}, {60., 0.}, {72., 0.}, {80., 0.}});
+
+        Interpolation interpolation(option::type("bilinear-remapping") | util::Config("non_linear", "missing-if-all-missing"), fs, pointcloud);
+
+        Field field_source = fs.createField<double>(option::name("source"));
+        field_source.metadata().set("missing_value", -3278.0);
+        field_source.metadata().set("missing_value_type", "approximately-equals");
+        field_source.metadata().set("missing_value_epsilon", 1e-6);
+        Field field_target("target", array::make_datatype<double>(), array::make_shape(pointcloud.size()));
+        field_target.metadata().set("missing_value", -3278.0);
+        field_target.metadata().set("missing_value_type", "approximately-equals");
+        field_target.metadata().set("missing_value_epsilon", 1e-6);
+
+        auto lonlat = array::make_view<double, 2>(fs.nodes().lonlat());
+        auto source = array::make_view<double, 1>(field_source);
+        for (idx_t j = 0; j < fs.nodes().size(); ++j) {
+            source(j) = func(lonlat(j, LON));
+        }
+
+        interpolation.execute(field_source, field_target);
+
+        auto target = array::make_view<double, 1>(field_target);
+
+        auto pc_view = array::make_view<double, 2>(pointcloud.lonlat());
+        std::vector<double> check;
+        for (int i = 0; i < pc_view.size(); ++i) {
+            check.push_back(func(pc_view(i, 0)));
+        }
+
+        atlas::field::MissingValue mv(field_target);
+        std::vector<bool> missing_vals(pointcloud.size(), true);
+
+        for (std::size_t j=0; j < target.size(); ++j) {
+          missing_vals[j] = mv(target(j));
+        }
+
+        for (idx_t j = 0; j < pointcloud.size(); ++j) {
+            static double interpolation_tolerance = 1.e-4;
+            char b = missing_vals[j] ? 'T' : 'F';
+            Log::info() << target(j) << "  " << check[j] << " " << b << std::endl;
+            EXPECT(eckit::types::is_approximately_equal(target(j), check[j], interpolation_tolerance));
+            EXPECT(!missing_vals[j]);
+        }
+    }
+}
+
+//-----------------------------------------------------------------------------
+
+}  // namespace test
+}  // namespace atlas
+
+int main(int argc, char** argv) {
+    return atlas::test::run(argc, argv);
+}

--- a/src/tests/test_orca_interpolation_bil.cc
+++ b/src/tests/test_orca_interpolation_bil.cc
@@ -40,16 +40,24 @@ CASE("test_interpolation_points_to_ORCA2_bilinear_remapping") {
 
     SECTION("at the equator, after seam") {
         PointCloud pointcloud({{80., 0.},
-                               {90., 0.},
                                {100., 0.},
-                               {110., 0.},
                                {120., 0.},
-                               {130., 0.},
                                {140., 0.},
-                               {150., 0.},
-                               {160., 0.}});
+                               {160., 0.},
+                               {180., 0.},
+                               {200., 0.},
+                               {220., 0.},
+                               {240., 0.},
+                               {260., 0.},
+                               {280., 0.},
+                               {300., 0.},
+                               {320., 0.},
+                               {340., 0.},
+                               {360., 0.}});
 
-        Interpolation interpolation(option::type("bilinear-remapping") | util::Config("non_linear", "missing-if-all-missing"), fs, pointcloud);
+        Interpolation interpolation(option::type("bilinear-remapping") |
+                                    util::Config("non_linear", "missing-if-all-missing") |
+                                    util::Config("max_fraction_elems_to_try", 0) , fs, pointcloud);
 
         Field field_source = fs.createField<double>(option::name("source"));
         field_source.metadata().set("missing_value", -3278.0);
@@ -95,7 +103,9 @@ CASE("test_interpolation_points_to_ORCA2_bilinear_remapping") {
         PointCloud pointcloud(
             {{00., 0.}, {10., 0.}, {20., 0.}, {30., 0.}, {40., 0.}, {50., 0.}, {60., 0.}, {72., 0.}, {80., 0.}});
 
-        Interpolation interpolation(option::type("bilinear-remapping") | util::Config("non_linear", "missing-if-all-missing"), fs, pointcloud);
+        Interpolation interpolation(option::type("bilinear-remapping") |
+                                    util::Config("non_linear", "missing-if-all-missing") |
+                                    util::Config("max_fraction_elems_to_try", 0) , fs, pointcloud);
 
         Field field_source = fs.createField<double>(option::name("source"));
         field_source.metadata().set("missing_value", -3278.0);

--- a/src/tests/test_orca_interpolation_bil.cc
+++ b/src/tests/test_orca_interpolation_bil.cc
@@ -53,6 +53,7 @@ CASE("test_interpolation_points_to_ORCA2_bilinear_remapping") {
                                {300., 0.},
                                {320., 0.},
                                {340., 0.},
+                               {359., 0.},
                                {360., 0.}});
 
         Interpolation interpolation(option::type("bilinear-remapping") |
@@ -91,10 +92,12 @@ CASE("test_interpolation_points_to_ORCA2_bilinear_remapping") {
           missing_vals[j] = mv(target(j));
         }
 
+        Log::info() << "(lon,lat): test ~= known-good - missing[T/F]"  << std::endl;
         for (idx_t j = 0; j < pointcloud.size(); ++j) {
             static double interpolation_tolerance = 1.e-4;
             char b = missing_vals[j] ? 'T' : 'F';
-            Log::info() << target(j) << "  " << check[j] << " " << b << std::endl;
+            Log::info() << "(" << pc_view(j,0) << " " << pc_view(j,1) << "): "
+                        << target(j) << " ~= " << check[j] << " - " << b << std::endl;
             EXPECT(eckit::types::is_approximately_equal(target(j), check[j], interpolation_tolerance));
             EXPECT(!missing_vals[j]);
         }
@@ -139,10 +142,12 @@ CASE("test_interpolation_points_to_ORCA2_bilinear_remapping") {
           missing_vals[j] = mv(target(j));
         }
 
+        Log::info() << "(lon,lat): test ~= known-good - missing[T/F]"  << std::endl;
         for (idx_t j = 0; j < pointcloud.size(); ++j) {
             static double interpolation_tolerance = 1.e-4;
             char b = missing_vals[j] ? 'T' : 'F';
-            Log::info() << target(j) << "  " << check[j] << " " << b << std::endl;
+            Log::info() << "(" << pc_view(j,0) << " " << pc_view(j,1) << "): "
+                        << target(j) << " ~= " << check[j] << " - " << b << std::endl;
             EXPECT(eckit::types::is_approximately_equal(target(j), check[j], interpolation_tolerance));
             EXPECT(!missing_vals[j]);
         }

--- a/src/tests/test_orca_interpolation_bil.cc
+++ b/src/tests/test_orca_interpolation_bil.cc
@@ -72,7 +72,7 @@ CASE("test_interpolation_points_to_ORCA2_bilinear_remapping") {
 
         auto pc_view = array::make_view<double, 2>(pointcloud.lonlat());
         std::vector<double> check;
-        for (int i = 0; i < pc_view.size(); ++i) {
+        for (int i = 0; i < pc_view.shape(0); ++i) {
             check.push_back(func(pc_view(i, 0)));
         }
 
@@ -118,7 +118,7 @@ CASE("test_interpolation_points_to_ORCA2_bilinear_remapping") {
 
         auto pc_view = array::make_view<double, 2>(pointcloud.lonlat());
         std::vector<double> check;
-        for (int i = 0; i < pc_view.size(); ++i) {
+        for (int i = 0; i < pc_view.shape(0); ++i) {
             check.push_back(func(pc_view(i, 0)));
         }
 


### PR DESCRIPTION
I have revisited my bilinear remapping interpolation PR in atlas ecmwf/atlas#85. This interpolation scheme only works at the moment if I undo this normalisation step in atlas-orca. 

I think I understand why this normalisation step is in here - there is a seam in the orca grid with an overlap. Multiple grid points share longitude/latitude positions. The normalisation step moves this seam to the edges of the mesh. I am still not quite sure why this change should lead to all points to the left of the seam being marked as missing. Its possible that the halo is not setup correctly, and I would be better off fixing that rather than making the change in this PR. Please let me know! 

I have made some plots to show the overlap in the orca2 and orca12 grids (ignore the black line, I was experimenting with showing the grid extent). In the ORCA2 grid the seam is around 80 degrees longitude in the file with this fix:
![orca2_t](https://user-images.githubusercontent.com/14909402/154512927-3660f4c9-961d-47f3-be51-2e2843cd0f38.png)

Before the change in this PR you can see that the points are no longer doubled up but the range has been shifted:
![orca2_t_nofix](https://user-images.githubusercontent.com/14909402/154513131-883a8f60-3258-42e9-b2c1-02d01e5cc42a.png)

The eorca12 grid has a similar seam, however it is harder to visualise due to the number of grid points. The seam is around longitude 72:
![eorca12_t_zoom](https://user-images.githubusercontent.com/14909402/154513829-e90502b4-d9cf-43b2-befa-86f958a6e98f.png)

I am not sure if it is in fact a connectivity issue, because the file generated by atlas-meshgen looks well connected in gmsh:
![seam_connectivity_cropped](https://user-images.githubusercontent.com/14909402/154520457-d696371d-0b68-4793-bdcf-cf2e085b2f9b.png)

#### Testing
This passes the ctests following the change, and the mesh looks identical because I believe it is based on the xy field rather than the lonlat field.

I have added a ctest that along with my ATLAS PR demonstrates the issue with and without this fix. The second section of the test will be marked missing if the unormalise longitude change is omitted.
