### PR TITLE
Test for partitioner failure

### DIFF
--- a/src/atlas-orca/meshgenerator/OrcaMeshGenerator.h
+++ b/src/atlas-orca/meshgenerator/OrcaMeshGenerator.h
@@ -55,6 +55,7 @@ private:
 
     bool include_pole_{false};
     bool fixup_{true};
+    int halosize_{0};
     int nparts_;
     int mypart_;
 };

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -32,3 +32,10 @@ ecbuild_add_test( TARGET  atlas_test_orca_valid_elements
                   LIBS    atlas-orca
                   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
                   CONDITION eckit_HAVE_LZ4 )
+
+ecbuild_add_test( TARGET  atlas_test_orca_partition
+                  SOURCES test_orca_partition.cc
+                  LIBS    atlas-orca
+                  MPI     2
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+                  CONDITION eckit_HAVE_LZ4 AND eckit_HAVE_MPI)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -24,8 +24,9 @@ ecbuild_add_test( TARGET  atlas_test_orca_grid
 ecbuild_add_test( TARGET  atlas_test_orca_mesh
                   SOURCES test_orca_mesh.cc
                   LIBS    atlas-orca
+                  MPI     2
                   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
-                  CONDITION eckit_HAVE_LZ4 )
+                  CONDITION eckit_HAVE_LZ4 AND eckit_HAVE_MPI)
 
 ecbuild_add_test( TARGET  atlas_test_orca_valid_elements
                   SOURCES test_orca_valid_elements.cc

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -39,3 +39,10 @@ ecbuild_add_test( TARGET  atlas_test_orca_partition
                   MPI     2
                   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
                   CONDITION eckit_HAVE_LZ4 AND eckit_HAVE_MPI)
+
+ecbuild_add_test( TARGET  atlas_test_orca_interpolation
+                  SOURCES test_orca_interpolation.cc
+                  LIBS    atlas-orca
+                  MPI     1
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+                  CONDITION eckit_HAVE_LZ4 AND eckit_HAVE_MPI)

--- a/src/tests/test_orca_interpolation.cc
+++ b/src/tests/test_orca_interpolation.cc
@@ -1,0 +1,164 @@
+/*
+ * (C) Crown Copyright 2022 Met Office
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#include <cmath>
+
+#include "eckit/types/FloatCompare.h"
+
+#include "atlas/array.h"
+#include "atlas/functionspace.h"
+#include "atlas/functionspace/PointCloud.h"
+#include "atlas/grid.h"
+#include "atlas/interpolation.h"
+#include "atlas/mesh.h"
+#include "atlas/meshgenerator.h"
+#include "atlas/util/CoordinateEnums.h"
+#include "atlas/field/MissingValue.h"
+
+#include "tests/AtlasTestEnvironment.h"
+
+using namespace eckit;
+using namespace atlas::functionspace;
+using namespace atlas::util;
+
+namespace atlas {
+namespace test {
+
+//-----------------------------------------------------------------------------
+//
+
+CASE("test interpolation points to ORCA2_T") {
+    Grid grid("ORCA2_T");
+    Mesh mesh(grid);
+    NodeColumns fs(mesh);
+
+    auto func = [](double x) -> double { return std::sin(x * M_PI / 180.); };
+
+    SECTION("at the equator, after seam") {
+        PointCloud pointcloud({{80., 0.},
+                               {100., 0.},
+                               {120., 0.},
+                               {140., 0.},
+                               {160., 0.},
+                               {180., 0.},
+                               {200., 0.},
+                               {220., 0.},
+                               {240., 0.},
+                               {260., 0.},
+                               {280., 0.},
+                               {300., 0.},
+                               {320., 0.},
+                               {340., 0.},
+                               {359., 0.},
+                               {360., 0.}});
+
+        Interpolation interpolation(option::type("unstructured-bilinear-lonlat") |
+                                    util::Config("non_linear", "missing-if-all-missing") |
+                                    util::Config("max_fraction_elems_to_try", 0) , fs, pointcloud);
+
+        Field field_source = fs.createField<double>(option::name("source"));
+        field_source.metadata().set("missing_value", -3278.0);
+        field_source.metadata().set("missing_value_type", "approximately-equals");
+        field_source.metadata().set("missing_value_epsilon", 1e-6);
+        Field field_target("target", array::make_datatype<double>(), array::make_shape(pointcloud.size()));
+        field_target.metadata().set("missing_value", -3278.0);
+        field_target.metadata().set("missing_value_type", "approximately-equals");
+        field_target.metadata().set("missing_value_epsilon", 1e-6);
+
+        auto lonlat = array::make_view<double, 2>(fs.nodes().lonlat());
+        auto source = array::make_view<double, 1>(field_source);
+        for (idx_t j = 0; j < fs.nodes().size(); ++j) {
+            source(j) = func(lonlat(j, LON));
+        }
+
+        interpolation.execute(field_source, field_target);
+
+        auto target = array::make_view<double, 1>(field_target);
+
+        auto pc_view = array::make_view<double, 2>(pointcloud.lonlat());
+        std::vector<double> check;
+        for (int i = 0; i < pc_view.shape(0); ++i) {
+            check.push_back(func(pc_view(i, 0)));
+        }
+
+        atlas::field::MissingValue mv(field_target);
+        std::vector<bool> missing_vals(pointcloud.size(), true);
+
+        for (std::size_t j=0; j < target.size(); ++j) {
+          missing_vals[j] = mv(target(j));
+        }
+
+        Log::info() << "(lon,lat): test ~= known-good - missing[T/F]"  << std::endl;
+        for (idx_t j = 0; j < pointcloud.size(); ++j) {
+            static double interpolation_tolerance = 1.e-4;
+            char b = missing_vals[j] ? 'T' : 'F';
+            Log::info() << "(" << pc_view(j,0) << " " << pc_view(j,1) << "): "
+                        << target(j) << " ~= " << check[j] << " - " << b << std::endl;
+            EXPECT(eckit::types::is_approximately_equal(target(j), check[j], interpolation_tolerance));
+            EXPECT(!missing_vals[j]);
+        }
+    }
+    SECTION("at the equator, before seam") {
+        PointCloud pointcloud(
+            {{00., 0.}, {10., 0.}, {20., 0.}, {30., 0.}, {40., 0.}, {50., 0.}, {60., 0.}, {72., 0.}, {80., 0.}});
+
+        Interpolation interpolation(option::type("unstructured-bilinear-lonlat") |
+                                    util::Config("non_linear", "missing-if-all-missing") |
+                                    util::Config("max_fraction_elems_to_try", 0) , fs, pointcloud);
+
+        Field field_source = fs.createField<double>(option::name("source"));
+        field_source.metadata().set("missing_value", -3278.0);
+        field_source.metadata().set("missing_value_type", "approximately-equals");
+        field_source.metadata().set("missing_value_epsilon", 1e-6);
+        Field field_target("target", array::make_datatype<double>(), array::make_shape(pointcloud.size()));
+        field_target.metadata().set("missing_value", -3278.0);
+        field_target.metadata().set("missing_value_type", "approximately-equals");
+        field_target.metadata().set("missing_value_epsilon", 1e-6);
+
+        auto lonlat = array::make_view<double, 2>(fs.nodes().lonlat());
+        auto source = array::make_view<double, 1>(field_source);
+        for (idx_t j = 0; j < fs.nodes().size(); ++j) {
+            source(j) = func(lonlat(j, LON));
+        }
+
+        interpolation.execute(field_source, field_target);
+
+        auto target = array::make_view<double, 1>(field_target);
+
+        auto pc_view = array::make_view<double, 2>(pointcloud.lonlat());
+        std::vector<double> check;
+        for (int i = 0; i < pc_view.shape(0); ++i) {
+            check.push_back(func(pc_view(i, 0)));
+        }
+
+        atlas::field::MissingValue mv(field_target);
+        std::vector<bool> missing_vals(pointcloud.size(), true);
+
+        for (std::size_t j=0; j < target.size(); ++j) {
+          missing_vals[j] = mv(target(j));
+        }
+
+        Log::info() << "(lon,lat): test ~= known-good - missing[T/F]"  << std::endl;
+        for (idx_t j = 0; j < pointcloud.size(); ++j) {
+            static double interpolation_tolerance = 1.e-4;
+            char b = missing_vals[j] ? 'T' : 'F';
+            Log::info() << "(" << pc_view(j,0) << " " << pc_view(j,1) << "): "
+                        << target(j) << " ~= " << check[j] << " - " << b << std::endl;
+            EXPECT(eckit::types::is_approximately_equal(target(j), check[j], interpolation_tolerance));
+            EXPECT(!missing_vals[j]);
+        }
+    }
+}
+
+//-----------------------------------------------------------------------------
+
+}  // namespace test
+}  // namespace atlas
+
+int main(int argc, char** argv) {
+    return atlas::test::run(argc, argv);
+}

--- a/src/tests/test_orca_partition.cc
+++ b/src/tests/test_orca_partition.cc
@@ -1,0 +1,127 @@
+/*
+ * (C) Copyright 2021- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include "eckit/log/Bytes.h"
+#include "eckit/system/ResourceUsage.h"
+
+#include "atlas/functionspace/NodeColumns.h"
+#include "atlas/grid.h"
+#include "atlas/mesh.h"
+#include "atlas/meshgenerator.h"
+#include "atlas/output/Gmsh.h"
+#include "atlas/util/Config.h"
+
+#include "atlas/util/Geometry.h"
+#include "atlas/util/LonLatMicroDeg.h"
+#include "atlas/util/PeriodicTransform.h"
+
+#include "atlas-orca/grid/OrcaGrid.h"
+#include "atlas-orca/util/PointIJ.h"
+
+#include "tests/AtlasTestEnvironment.h"
+
+namespace atlas {
+namespace test {
+
+//-----------------------------------------------------------------------------
+
+CASE( "test orca partition is full" ) {
+    auto gridnames = std::vector<std::string>{
+        "ORCA2_T",   //
+        "eORCA1_T",  //
+        //"eORCA025_T",  //
+    };
+    auto methodnames = std::vector<std::string>{
+        "bands",   //
+        "equal_regions",  //
+        "checkerboard",  //
+    };
+    for ( auto gridname : gridnames ) {
+      auto grid = Grid( gridname );
+      for ( auto method : methodnames ) {
+        SECTION( gridname + std::string(" ") + method) {
+            idx_t mypart = static_cast<idx_t>(mpi::rank());
+            auto meshgenerator = MeshGenerator{"orca"};
+            grid::Partitioner partitioner(method, atlas::mpi::size());
+            auto mesh = meshgenerator.generate( grid, partitioner );
+            auto part = array::make_view<int, 1>(mesh.nodes().partition());
+
+            std::vector<int> counts(mpi::size());
+            for (int p = 0; p<part.size(); p++) {
+              ++counts[part(p)];
+              if (part(p) < 0)
+                std::cout << "[" << mypart << "] part(" << p << ") " << part(p) << std::endl;
+              ASSERT(part(p) >= 0);
+            }
+            //for (int p = 0; p<mpi::size(); p++)
+            //  std::cout << "[" << mypart << "] counts[" << p << "] " << counts[p] << std::endl;
+        }
+      }
+    }
+}
+
+CASE( "test orca partition construction inside meshgenerator.generate" ) {
+
+    auto gridnames = std::vector<std::string>{
+        "ORCA2_T",   //
+        "eORCA1_T",  //
+        //"eORCA025_T",  //
+    };
+    auto methodnames = std::vector<std::string>{
+        "bands",   //
+        "equal_regions",  //
+        "checkerboard",  //
+    };
+    for ( auto gridname : gridnames ) {
+      auto grid = Grid( gridname );
+      for ( auto method : methodnames ) {
+        SECTION( gridname + std::string(" ") + method) {
+          auto meshgenerator = MeshGenerator{"orca"};
+          grid::Partitioner partitioner("equal_regions", atlas::mpi::size());
+          auto mesh = meshgenerator.generate(grid, partitioner);
+        }
+      }
+    }
+}
+
+CASE( "test orca available partitioners" ) {
+    auto gridnames = std::vector<std::string>{
+        "ORCA2_T",   //
+        "eORCA1_T",  //
+        //"eORCA025_T",  //
+    };
+    auto methodnames = std::vector<std::string>{
+        "bands",   //
+        "equal_regions",  //
+        "checkerboard",  //
+    };
+    for ( auto gridname : gridnames ) {
+      auto grid = Grid( gridname );
+      for ( auto method : methodnames ) {
+        SECTION( gridname + std::string(" ") + method) {
+            grid::Partitioner partitioner(method, atlas::mpi::size());
+            grid::Distribution distribution = partitioner.partition(grid);
+        }
+        SECTION( gridname + std::string(" ") + method + std::string(" from config ")) {
+            auto config = grid.partitioner();  // recommended by the grid itself
+            config.set("type", method);
+            grid::Partitioner partitioner = grid::Partitioner{config};
+            grid::Distribution distribution = partitioner.partition(grid);
+        }
+      }
+    }
+}
+
+}  // namespace test
+}  // namespace atlas
+
+int main( int argc, char** argv ) {
+    return atlas::test::run( argc, argv );
+}

--- a/src/tests/test_orca_partition.cc
+++ b/src/tests/test_orca_partition.cc
@@ -53,15 +53,11 @@ CASE( "test orca partition is full" ) {
             auto mesh = meshgenerator.generate( grid, partitioner );
             auto part = array::make_view<int, 1>(mesh.nodes().partition());
 
-            std::vector<int> counts(mpi::size());
             for (int p = 0; p<part.size(); p++) {
-              ++counts[part(p)];
               if (part(p) < 0)
                 std::cout << "[" << mypart << "] part(" << p << ") " << part(p) << std::endl;
               ASSERT(part(p) >= 0);
             }
-            //for (int p = 0; p<mpi::size(); p++)
-            //  std::cout << "[" << mypart << "] counts[" << p << "] " << counts[p] << std::endl;
         }
       }
     }
@@ -84,36 +80,8 @@ CASE( "test orca partition construction inside meshgenerator.generate" ) {
       for ( auto method : methodnames ) {
         SECTION( gridname + std::string(" ") + method) {
           auto meshgenerator = MeshGenerator{"orca"};
-          grid::Partitioner partitioner("equal_regions", atlas::mpi::size());
+          grid::Partitioner partitioner(method, atlas::mpi::size());
           auto mesh = meshgenerator.generate(grid, partitioner);
-        }
-      }
-    }
-}
-
-CASE( "test orca available partitioners" ) {
-    auto gridnames = std::vector<std::string>{
-        "ORCA2_T",   //
-        "eORCA1_T",  //
-        //"eORCA025_T",  //
-    };
-    auto methodnames = std::vector<std::string>{
-        "bands",   //
-        "equal_regions",  //
-        "checkerboard",  //
-    };
-    for ( auto gridname : gridnames ) {
-      auto grid = Grid( gridname );
-      for ( auto method : methodnames ) {
-        SECTION( gridname + std::string(" ") + method) {
-            grid::Partitioner partitioner(method, atlas::mpi::size());
-            grid::Distribution distribution = partitioner.partition(grid);
-        }
-        SECTION( gridname + std::string(" ") + method + std::string(" from config ")) {
-            auto config = grid.partitioner();  // recommended by the grid itself
-            config.set("type", method);
-            grid::Partitioner partitioner = grid::Partitioner{config};
-            grid::Distribution distribution = partitioner.partition(grid);
         }
       }
     }


### PR DESCRIPTION
## Description

My application as well as `atlas-meshgen` are reporting errors in `BuildParallelFields.cc` with orca grids when using multiple processors.

I think this issue has something to do with `atlas-orca`, but I am not sure. I haven't made much progress identifying the source of the issue, but these are some tests to begin to understand what is going wrong.

When running `mpirun -np 16 ./bin/atlas-meshgen ORCA2_T` I am seeing errors like:
```
[0] Node requested by rank [7] with uid [940563842883868512] that should be owned is not found
```
or many messages of the form:
```
[0] Node with global index 12923 not found on part [7]
```
My first instinct was that somehow the partition is not getting set properly by the mesh generator, although I admit I am still a bit confused about how everything fits together! I have written a few tests. 

So far I can't reproduce the errors above in my tests, however, I do find that calling the partitioner within `meshgenerator.generate` will let me run the `checkerboard` partitioner, but using `partitioner.partition(grid)` will throw the following exception:
```
"test orca available partitioners (section: ORCA2_T checkerboard)" failed with unhandled eckit::Exception: Checkerboard Partitioner only works for Regular grids.
```

I am still experimenting with this, hopefully I will be able to add more information via further tests here.