### PR TITLE
Add halo during mesh generation

### DIFF
--- a/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
+++ b/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
@@ -723,7 +723,7 @@ void OrcaMeshGenerator::build_remote_index(Mesh& mesh) {
     int nb_nodes = nodes.size();
 
     // get the indices and partition data
-    auto master_glb_idx = array::make_indexview<gidx_t, 1>(nodes.field("master_global_index"));
+    auto master_glb_idx = array::make_view<gidx_t, 1>(nodes.field("master_global_index"));
     auto glb_idx        = array::make_view<gidx_t, 1>( mesh.nodes().global_index() );
     auto ridx    = array::make_indexview<idx_t, 1>( nodes.remote_index() );
     auto part    = array::make_view<int, 1>( nodes.partition() );

--- a/src/atlas-orca/meshgenerator/OrcaMeshGenerator.h
+++ b/src/atlas-orca/meshgenerator/OrcaMeshGenerator.h
@@ -53,6 +53,8 @@ public:
 private:
     void hash( eckit::Hash& ) const override;
 
+    static void build_remote_index(Mesh& mesh);
+
     bool include_pole_{false};
     bool fixup_{true};
     int halosize_{0};

--- a/src/atlas-orca/meshgenerator/OrcaMeshGenerator.h
+++ b/src/atlas-orca/meshgenerator/OrcaMeshGenerator.h
@@ -55,6 +55,7 @@ private:
 
     bool include_pole_{false};
     bool fixup_{true};
+    int halosize_{0};
     int nparts_;
     int mypart_;
 };

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -32,3 +32,10 @@ ecbuild_add_test( TARGET  atlas_test_orca_valid_elements
                   LIBS    atlas-orca
                   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
                   CONDITION eckit_HAVE_LZ4 )
+
+ecbuild_add_test( TARGET  atlas_test_orca_partition
+                  SOURCES test_orca_partition.cc
+                  LIBS    atlas-orca
+                  MPI     2
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+                  CONDITION eckit_HAVE_LZ4 AND eckit_HAVE_MPI)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -24,8 +24,9 @@ ecbuild_add_test( TARGET  atlas_test_orca_grid
 ecbuild_add_test( TARGET  atlas_test_orca_mesh
                   SOURCES test_orca_mesh.cc
                   LIBS    atlas-orca
+                  MPI     2
                   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
-                  CONDITION eckit_HAVE_LZ4 )
+                  CONDITION eckit_HAVE_LZ4 AND eckit_HAVE_MPI)
 
 ecbuild_add_test( TARGET  atlas_test_orca_valid_elements
                   SOURCES test_orca_valid_elements.cc

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -39,3 +39,10 @@ ecbuild_add_test( TARGET  atlas_test_orca_partition
                   MPI     2
                   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
                   CONDITION eckit_HAVE_LZ4 AND eckit_HAVE_MPI)
+
+ecbuild_add_test( TARGET  atlas_test_orca_interpolation
+                  SOURCES test_orca_interpolation.cc
+                  LIBS    atlas-orca
+                  MPI     1
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+                  CONDITION eckit_HAVE_LZ4 AND eckit_HAVE_MPI)

--- a/src/tests/test_orca_interpolation.cc
+++ b/src/tests/test_orca_interpolation.cc
@@ -1,0 +1,164 @@
+/*
+ * (C) Crown Copyright 2022 Met Office
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#include <cmath>
+
+#include "eckit/types/FloatCompare.h"
+
+#include "atlas/array.h"
+#include "atlas/functionspace.h"
+#include "atlas/functionspace/PointCloud.h"
+#include "atlas/grid.h"
+#include "atlas/interpolation.h"
+#include "atlas/mesh.h"
+#include "atlas/meshgenerator.h"
+#include "atlas/util/CoordinateEnums.h"
+#include "atlas/field/MissingValue.h"
+
+#include "tests/AtlasTestEnvironment.h"
+
+using namespace eckit;
+using namespace atlas::functionspace;
+using namespace atlas::util;
+
+namespace atlas {
+namespace test {
+
+//-----------------------------------------------------------------------------
+//
+
+CASE("test interpolation points to ORCA2_T") {
+    Grid grid("ORCA2_T");
+    Mesh mesh(grid);
+    NodeColumns fs(mesh);
+
+    auto func = [](double x) -> double { return std::sin(x * M_PI / 180.); };
+
+    SECTION("at the equator, after seam") {
+        PointCloud pointcloud({{80., 0.},
+                               {100., 0.},
+                               {120., 0.},
+                               {140., 0.},
+                               {160., 0.},
+                               {180., 0.},
+                               {200., 0.},
+                               {220., 0.},
+                               {240., 0.},
+                               {260., 0.},
+                               {280., 0.},
+                               {300., 0.},
+                               {320., 0.},
+                               {340., 0.},
+                               {359., 0.},
+                               {360., 0.}});
+
+        Interpolation interpolation(option::type("unstructured-bilinear-lonlat") |
+                                    util::Config("non_linear", "missing-if-all-missing") |
+                                    util::Config("max_fraction_elems_to_try", 0) , fs, pointcloud);
+
+        Field field_source = fs.createField<double>(option::name("source"));
+        field_source.metadata().set("missing_value", -3278.0);
+        field_source.metadata().set("missing_value_type", "approximately-equals");
+        field_source.metadata().set("missing_value_epsilon", 1e-6);
+        Field field_target("target", array::make_datatype<double>(), array::make_shape(pointcloud.size()));
+        field_target.metadata().set("missing_value", -3278.0);
+        field_target.metadata().set("missing_value_type", "approximately-equals");
+        field_target.metadata().set("missing_value_epsilon", 1e-6);
+
+        auto lonlat = array::make_view<double, 2>(fs.nodes().lonlat());
+        auto source = array::make_view<double, 1>(field_source);
+        for (idx_t j = 0; j < fs.nodes().size(); ++j) {
+            source(j) = func(lonlat(j, LON));
+        }
+
+        interpolation.execute(field_source, field_target);
+
+        auto target = array::make_view<double, 1>(field_target);
+
+        auto pc_view = array::make_view<double, 2>(pointcloud.lonlat());
+        std::vector<double> check;
+        for (int i = 0; i < pc_view.shape(0); ++i) {
+            check.push_back(func(pc_view(i, 0)));
+        }
+
+        atlas::field::MissingValue mv(field_target);
+        std::vector<bool> missing_vals(pointcloud.size(), true);
+
+        for (std::size_t j=0; j < target.size(); ++j) {
+          missing_vals[j] = mv(target(j));
+        }
+
+        Log::info() << "(lon,lat): test ~= known-good - missing[T/F]"  << std::endl;
+        for (idx_t j = 0; j < pointcloud.size(); ++j) {
+            static double interpolation_tolerance = 1.e-4;
+            char b = missing_vals[j] ? 'T' : 'F';
+            Log::info() << "(" << pc_view(j,0) << " " << pc_view(j,1) << "): "
+                        << target(j) << " ~= " << check[j] << " - " << b << std::endl;
+            EXPECT(eckit::types::is_approximately_equal(target(j), check[j], interpolation_tolerance));
+            EXPECT(!missing_vals[j]);
+        }
+    }
+    SECTION("at the equator, before seam") {
+        PointCloud pointcloud(
+            {{00., 0.}, {10., 0.}, {20., 0.}, {30., 0.}, {40., 0.}, {50., 0.}, {60., 0.}, {72., 0.}, {80., 0.}});
+
+        Interpolation interpolation(option::type("unstructured-bilinear-lonlat") |
+                                    util::Config("non_linear", "missing-if-all-missing") |
+                                    util::Config("max_fraction_elems_to_try", 0) , fs, pointcloud);
+
+        Field field_source = fs.createField<double>(option::name("source"));
+        field_source.metadata().set("missing_value", -3278.0);
+        field_source.metadata().set("missing_value_type", "approximately-equals");
+        field_source.metadata().set("missing_value_epsilon", 1e-6);
+        Field field_target("target", array::make_datatype<double>(), array::make_shape(pointcloud.size()));
+        field_target.metadata().set("missing_value", -3278.0);
+        field_target.metadata().set("missing_value_type", "approximately-equals");
+        field_target.metadata().set("missing_value_epsilon", 1e-6);
+
+        auto lonlat = array::make_view<double, 2>(fs.nodes().lonlat());
+        auto source = array::make_view<double, 1>(field_source);
+        for (idx_t j = 0; j < fs.nodes().size(); ++j) {
+            source(j) = func(lonlat(j, LON));
+        }
+
+        interpolation.execute(field_source, field_target);
+
+        auto target = array::make_view<double, 1>(field_target);
+
+        auto pc_view = array::make_view<double, 2>(pointcloud.lonlat());
+        std::vector<double> check;
+        for (int i = 0; i < pc_view.shape(0); ++i) {
+            check.push_back(func(pc_view(i, 0)));
+        }
+
+        atlas::field::MissingValue mv(field_target);
+        std::vector<bool> missing_vals(pointcloud.size(), true);
+
+        for (std::size_t j=0; j < target.size(); ++j) {
+          missing_vals[j] = mv(target(j));
+        }
+
+        Log::info() << "(lon,lat): test ~= known-good - missing[T/F]"  << std::endl;
+        for (idx_t j = 0; j < pointcloud.size(); ++j) {
+            static double interpolation_tolerance = 1.e-4;
+            char b = missing_vals[j] ? 'T' : 'F';
+            Log::info() << "(" << pc_view(j,0) << " " << pc_view(j,1) << "): "
+                        << target(j) << " ~= " << check[j] << " - " << b << std::endl;
+            EXPECT(eckit::types::is_approximately_equal(target(j), check[j], interpolation_tolerance));
+            EXPECT(!missing_vals[j]);
+        }
+    }
+}
+
+//-----------------------------------------------------------------------------
+
+}  // namespace test
+}  // namespace atlas
+
+int main(int argc, char** argv) {
+    return atlas::test::run(argc, argv);
+}

--- a/src/tests/test_orca_partition.cc
+++ b/src/tests/test_orca_partition.cc
@@ -1,0 +1,127 @@
+/*
+ * (C) Copyright 2021- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include "eckit/log/Bytes.h"
+#include "eckit/system/ResourceUsage.h"
+
+#include "atlas/functionspace/NodeColumns.h"
+#include "atlas/grid.h"
+#include "atlas/mesh.h"
+#include "atlas/meshgenerator.h"
+#include "atlas/output/Gmsh.h"
+#include "atlas/util/Config.h"
+
+#include "atlas/util/Geometry.h"
+#include "atlas/util/LonLatMicroDeg.h"
+#include "atlas/util/PeriodicTransform.h"
+
+#include "atlas-orca/grid/OrcaGrid.h"
+#include "atlas-orca/util/PointIJ.h"
+
+#include "tests/AtlasTestEnvironment.h"
+
+namespace atlas {
+namespace test {
+
+//-----------------------------------------------------------------------------
+
+CASE( "test orca partition is full" ) {
+    auto gridnames = std::vector<std::string>{
+        "ORCA2_T",   //
+        "eORCA1_T",  //
+        //"eORCA025_T",  //
+    };
+    auto methodnames = std::vector<std::string>{
+        "bands",   //
+        "equal_regions",  //
+        "checkerboard",  //
+    };
+    for ( auto gridname : gridnames ) {
+      auto grid = Grid( gridname );
+      for ( auto method : methodnames ) {
+        SECTION( gridname + std::string(" ") + method) {
+            idx_t mypart = static_cast<idx_t>(mpi::rank());
+            auto meshgenerator = MeshGenerator{"orca"};
+            grid::Partitioner partitioner(method, atlas::mpi::size());
+            auto mesh = meshgenerator.generate( grid, partitioner );
+            auto part = array::make_view<int, 1>(mesh.nodes().partition());
+
+            std::vector<int> counts(mpi::size());
+            for (int p = 0; p<part.size(); p++) {
+              ++counts[part(p)];
+              if (part(p) < 0)
+                std::cout << "[" << mypart << "] part(" << p << ") " << part(p) << std::endl;
+              ASSERT(part(p) >= 0);
+            }
+            //for (int p = 0; p<mpi::size(); p++)
+            //  std::cout << "[" << mypart << "] counts[" << p << "] " << counts[p] << std::endl;
+        }
+      }
+    }
+}
+
+CASE( "test orca partition construction inside meshgenerator.generate" ) {
+
+    auto gridnames = std::vector<std::string>{
+        "ORCA2_T",   //
+        "eORCA1_T",  //
+        //"eORCA025_T",  //
+    };
+    auto methodnames = std::vector<std::string>{
+        "bands",   //
+        "equal_regions",  //
+        "checkerboard",  //
+    };
+    for ( auto gridname : gridnames ) {
+      auto grid = Grid( gridname );
+      for ( auto method : methodnames ) {
+        SECTION( gridname + std::string(" ") + method) {
+          auto meshgenerator = MeshGenerator{"orca"};
+          grid::Partitioner partitioner("equal_regions", atlas::mpi::size());
+          auto mesh = meshgenerator.generate(grid, partitioner);
+        }
+      }
+    }
+}
+
+CASE( "test orca available partitioners" ) {
+    auto gridnames = std::vector<std::string>{
+        "ORCA2_T",   //
+        "eORCA1_T",  //
+        //"eORCA025_T",  //
+    };
+    auto methodnames = std::vector<std::string>{
+        "bands",   //
+        "equal_regions",  //
+        "checkerboard",  //
+    };
+    for ( auto gridname : gridnames ) {
+      auto grid = Grid( gridname );
+      for ( auto method : methodnames ) {
+        SECTION( gridname + std::string(" ") + method) {
+            grid::Partitioner partitioner(method, atlas::mpi::size());
+            grid::Distribution distribution = partitioner.partition(grid);
+        }
+        SECTION( gridname + std::string(" ") + method + std::string(" from config ")) {
+            auto config = grid.partitioner();  // recommended by the grid itself
+            config.set("type", method);
+            grid::Partitioner partitioner = grid::Partitioner{config};
+            grid::Distribution distribution = partitioner.partition(grid);
+        }
+      }
+    }
+}
+
+}  // namespace test
+}  // namespace atlas
+
+int main( int argc, char** argv ) {
+    return atlas::test::run( argc, argv );
+}

--- a/src/tests/test_orca_partition.cc
+++ b/src/tests/test_orca_partition.cc
@@ -53,15 +53,11 @@ CASE( "test orca partition is full" ) {
             auto mesh = meshgenerator.generate( grid, partitioner );
             auto part = array::make_view<int, 1>(mesh.nodes().partition());
 
-            std::vector<int> counts(mpi::size());
             for (int p = 0; p<part.size(); p++) {
-              ++counts[part(p)];
               if (part(p) < 0)
                 std::cout << "[" << mypart << "] part(" << p << ") " << part(p) << std::endl;
               ASSERT(part(p) >= 0);
             }
-            //for (int p = 0; p<mpi::size(); p++)
-            //  std::cout << "[" << mypart << "] counts[" << p << "] " << counts[p] << std::endl;
         }
       }
     }
@@ -84,36 +80,8 @@ CASE( "test orca partition construction inside meshgenerator.generate" ) {
       for ( auto method : methodnames ) {
         SECTION( gridname + std::string(" ") + method) {
           auto meshgenerator = MeshGenerator{"orca"};
-          grid::Partitioner partitioner("equal_regions", atlas::mpi::size());
+          grid::Partitioner partitioner(method, atlas::mpi::size());
           auto mesh = meshgenerator.generate(grid, partitioner);
-        }
-      }
-    }
-}
-
-CASE( "test orca available partitioners" ) {
-    auto gridnames = std::vector<std::string>{
-        "ORCA2_T",   //
-        "eORCA1_T",  //
-        //"eORCA025_T",  //
-    };
-    auto methodnames = std::vector<std::string>{
-        "bands",   //
-        "equal_regions",  //
-        "checkerboard",  //
-    };
-    for ( auto gridname : gridnames ) {
-      auto grid = Grid( gridname );
-      for ( auto method : methodnames ) {
-        SECTION( gridname + std::string(" ") + method) {
-            grid::Partitioner partitioner(method, atlas::mpi::size());
-            grid::Distribution distribution = partitioner.partition(grid);
-        }
-        SECTION( gridname + std::string(" ") + method + std::string(" from config ")) {
-            auto config = grid.partitioner();  // recommended by the grid itself
-            config.set("type", method);
-            grid::Partitioner partitioner = grid::Partitioner{config};
-            grid::Distribution distribution = partitioner.partition(grid);
         }
       }
     }


### PR DESCRIPTION
### Description

The ORCA grids have halo cells included in the grid. This makes building halos in the usual way problematic, as the mesh already contains duplicate nodes.

To get around this, I am attempting to construct the halo during the mesh generation, and set "halo_locked" to prevent failures in BuildHalo.cc.

The mesh generator creates a "surrounding rectangle" around all indices that should be on a given partition. I have extended this to include the additional nodes out to the halo width. Later, I include nodes that are within halo width of the current partition as nodes within the mesh.

### Testing

When I attempt to plot the nodes used in a halo by other partitions I seem to have a band around the perimeter that is not included. For example, partition 1 with 6 processors and a halo of 2 gives me the following image:

<img src="https://user-images.githubusercontent.com/14909402/175970252-e6258da2-d31b-40b6-9830-c91054169ac6.png" width="400">

I would expect to have the edge nodes to have a halo of 1, and then the next nodes in to have a halo of 2, instead there is a band of halo 0 around the outside edge. I have compared these images with the halo variable that is included as part of the gmsh info file output, and I am not exactly sure if this is an issue! It is possible everything is working correctly, but if there is a better way to test please let me know.

I have also tested this by reading and writing ORCA data from file into and out of atlas running on 4 and 2 processors with the equal-regions partitioner. I am doing this by converting the `ij` indices back to the native orca indices (including the orca halo points because these are also included in the output files):
```
  const int glb_i = ij(inode, 0) + orcaGrid_.haloWest();
  const int glb_j = ij(inode, 1) + orcaGrid_.haloSouth();
```
This reveals an additional discrepancy at some of the grid fold/seam points near the north poles I think. For example for ORCA2 the relevent points are:
```
 glb_i 89  glb_j 146  lon 260 lat 69.7133
 glb_i 90  glb_j 146  lon 260 lat 69.7133
 glb_i 181 glb_j 146  lon 440 lat 49.9789
 glb_i 0   glb_j 147  lon 80 lat 50.5255
 glb_i 89  glb_j 147  lon 260 lat 70
 glb_i 90  glb_j 147  lon 260 lat 70
 glb_i 92  glb_j 147  lon 260 lat 70
 glb_i 93  glb_j 147  lon 260 lat 70
 glb_i 94  glb_j 147  lon 260 lat 70
 glb_i 95  glb_j 147  lon 260 lat 70
 glb_i 96  glb_j 147  lon 260 lat 70
 glb_i 97  glb_j 147  lon 260 lat 70
 glb_i 98  glb_j 147  lon 260 lat 70
 glb_i 99  glb_j 147  lon 260 lat 70
 glb_i 100 glb_j 147  lon 260 lat 70
 glb_i 101 glb_j 147  lon 260 lat 70
 glb_i 0   glb_j 148  lon 80.221 lat 50.5161
 glb_i 1   glb_j 148  lon 80 lat 49.9789
 glb_i 89  glb_j 148  lon 260 lat 69.7133
 glb_i 90  glb_j 148  lon 260 lat 69.7133
 glb_i 91  glb_j 148  lon 260 lat 69.7133
 glb_i 92  glb_j 148  lon 260 lat 69.7133
 glb_i 93  glb_j 148  lon 260 lat 69.7133
 glb_i 180 glb_j 148  lon 440.221 lat 50.5161
 glb_i 181 glb_j 148  lon 440 lat 49.9789
```
These points result in missing data that was not being transferred by the halo swap:
![orca2_using_buildParallelFields](https://user-images.githubusercontent.com/14909402/177761239-5d85bac9-b15f-4a17-a943-a099198e3ad3.png)

I can resolve these points using the changes prototyped in test_atlas_orca_mesh::build_periodic_boundaries, and turning off the generic buildParallelFields and buildPeriodicBoundaries by setting `mesh.nodes().metadata().set( "parallel", true ); mesh.metadata().set( "periodic", true );`:

![orca2_no_parafields](https://user-images.githubusercontent.com/14909402/177762278-861e65d9-1574-4255-90ed-df3f950ee803.png)

### Remaining issues

* Is it OK to have switched off buildParallelFields and buildPeriodicBoundaries?
* Is there any other information I need to swap between partitions besides the remote index to setup a valid halo exchange?
* Are there any more tests you can suggest that I ought to incorperate into this change?

