### PR TITLE
Add test for the polygon locator on an ORCA grid

### DIFF
--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -32,3 +32,11 @@ ecbuild_add_test( TARGET  atlas_test_orca_valid_elements
                   LIBS    atlas-orca
                   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
                   CONDITION eckit_HAVE_LZ4 )
+
+ecbuild_add_test( TARGET  atlas_test_orca_polygon_locator
+                  SOURCES test_orca_polygon_locator.cc
+                  LIBS    atlas-orca
+                  MPI     2
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+                  CONDITION eckit_HAVE_LZ4 AND eckit_HAVE_MPI)
+

--- a/src/tests/test_orca_polygon_locator.cc
+++ b/src/tests/test_orca_polygon_locator.cc
@@ -1,0 +1,69 @@
+/*
+ * (C) Copyright 2021- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include <numeric>
+
+#include "atlas/functionspace/NodeColumns.h"
+#include "atlas/grid.h"
+#include "atlas/mesh.h"
+#include "atlas/meshgenerator.h"
+#include "atlas/util/Config.h"
+
+#include "atlas/util/PolygonLocator.h"
+#include "atlas/util/PolygonXY.h"
+
+#include "atlas-orca/grid/OrcaGrid.h"
+
+#include "tests/AtlasTestEnvironment.h"
+
+using Grid   = atlas::Grid;
+using Config = atlas::util::Config;
+
+namespace atlas {
+namespace test {
+
+//-----------------------------------------------------------------------------
+
+CASE( "test orca polygon locator" ) {
+    auto gridnames = std::vector<std::string>{
+        //"ORCA2_T",   //
+        //"eORCA1_T",  //
+        "eORCA025_T",  //
+        //"eORCA12_T",  //
+    };
+    for ( auto gridname : gridnames ) {
+        SECTION( gridname ) {
+            OrcaGrid grid      = Grid( gridname );
+            grid::Partitioner partitioner("equal_regions", atlas::mpi::size());
+            auto meshgenerator = MeshGenerator{"orca"};
+            auto mesh          = meshgenerator.generate( grid, partitioner );
+            REQUIRE( mesh.grid() );
+            EXPECT( mesh.grid().name() == gridname );
+            atlas::util::ListPolygonXY polygon_list(mesh.polygons());
+            //mesh.polygon(0).outputPythonScript("polygon.py",
+            //                                   Config("nodes", false)("coordinates", "xy"));
+            atlas::util::PolygonLocator locator(polygon_list, mesh.projection());
+
+            // fails on ORCA2 because partition polygon is not connected space
+            // (ORCA2 grids have a cut out area for the mediterranean)
+            idx_t part = locator({82.0, 10.0});
+            // would fail on ORCA025 because xy coordinate system doesn't cover
+            // 0-360. A fix for this has been added to the locator in atlas.
+            part = locator({-173.767, -61.1718});
+        }
+    }
+}
+
+}  // namespace test
+}  // namespace atlas
+
+int main( int argc, char** argv ) {
+    return atlas::test::run( argc, argv );
+}


### PR DESCRIPTION
## Description

The atlas [polygon locator](https://github.com/ecmwf/atlas/blob/develop/src/atlas/util/PolygonLocator.h) identifies the partition that owns a target point. This doesn't work properly on ORCA grids, and this test is here to expose this weakness.

Partly this is due to the use of longitude/latitude coordinates in the polygon locator, however for ORCA grids these cannot be assumed to lie between 0-360.

This test exposes this weakness in the ORCA025 grid. Every grid apart from ORCA2 seems to fail in the same way. The ORCA2 grid will also fail, however this is a more serious issue that I am not sure how to resolve and I am not sure it is worth it at this time. I believe this is down to the identification of polygons on an ORCA2 grid. The ORCA2 grid contains a cut-out area for the mediterranean. This region has a tendency to make the partition polygon non-convex, which I believe breaks the assumptions of the polygon locator. The ORCA2 grid is very small and unlikely to need to run under MPI, however it is worth pointing this behaviour out in case it affects other grids.

An example of the orca2 grid partition polygon under equal regions:
![orca2_polygon_eq_regions_fail](https://user-images.githubusercontent.com/14909402/188635716-5b8d73de-5954-443d-baf3-8f95aa53b047.png)


An example under the checkerboard partitioner:

![orca2_polygon_checkerboard_fail](https://user-images.githubusercontent.com/14909402/188635791-38a2fcec-f2a9-49af-994e-ae10d2c066bf.png)

The underlying 2D orca2 grid:

![orca2_grid](https://user-images.githubusercontent.com/14909402/188676089-26860fae-2d1d-4f03-afb4-1ab5c693e637.png)
