### PR TITLE
Detect NetCDF.

### DIFF
--- a/src/apps/atlas-orca-convert/CMakeLists.txt
+++ b/src/apps/atlas-orca-convert/CMakeLists.txt
@@ -7,6 +7,9 @@
 # granted to it by virtue of its status as an intergovernmental organisation nor
 # does it submit to any jurisdiction.
 
+find_package( jedicmake REQUIRED )  # Prefer find modules from jedi-cmake
+find_package( NetCDF COMPONENTS C CXX )
+
 # Overcome Cray linking problem where the C++ library is not linked with the C library
 list( APPEND NetCDF_CXX_EXTRA_LIBRARIES NetCDF::NetCDF_C )
 


### PR DESCRIPTION
This addresses https://github.com/wdeconinck/atlas-orca/issues/7, not sure if it is a good solution.  This allows NetCDF to be detected when NetCDF components (C, C++ and Fortran) are compiled in different places.