### PR TITLE
Update known URLs to new URL naming scheme

### DIFF
--- a/src/atlas-orca/util/OrcaDataFile.h
+++ b/src/atlas-orca/util/OrcaDataFile.h
@@ -33,8 +33,8 @@ namespace orca {
 
 static std::vector<std::string> known_urls() {
     std::vector<std::string> urls;
-    urls.emplace_back("http://get.ecmwf.int/atlas/grids/orca");
-    urls.emplace_back("https://get.ecmwf.int/atlas/grids/orca");
+    urls.emplace_back("http://get.ecmwf.int/repository/atlas/grids/orca");
+    urls.emplace_back("https://get.ecmwf.int/repository/atlas/grids/orca");
     return urls;
 }
 


### PR DESCRIPTION
### Description

Using `ATLAS_DATA_PATH` environment variable to define the path to our local cache of grid data no longer works. We suspect the issue might be related to yesterdays change in: f0b9d2d6378a5047acceae846fa6de3fae8bcb5d

This change updates the known URLs to reflect this change. This is enough to allow atlas orca to check the local cache of data before downloading from the internet.

### Issues

Fixes ecmwf/atlas-orca/issues/10