### PR TITLE
Feature/in memory cache for multio simulations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,11 +23,11 @@ if( NOT eckit_HAVE_LZ4 )
 endif()
 
 ecbuild_add_option( FEATURE RETRIEVE_ORCA_DATA
-	                  DEFAULT OFF
+                    DEFAULT OFF
                     DESCRIPTION "Retrieve all available atlas-orca binary data during build step." )
 
 ecbuild_add_option( FEATURE ORCA_IN_MEMORY_CACHE
-	                  DEFAULT OFF
+                    DEFAULT OFF
                     DESCRIPTION "Cache the orca data in order to avoid multiple loads from file" )
 
 # The above is equivalent to calling as part of build step:
@@ -44,7 +44,7 @@ ecbuild_add_option( FEATURE ORCA_IN_MEMORY_CACHE
 #
 
 ecbuild_add_option( FEATURE INSTALL_ORCA_DATA
-	                  DEFAULT OFF
+                    DEFAULT OFF
                     DESCRIPTION "Install available atlas-orca binary data present in build dir" )
 
 atlas_create_plugin( atlas-orca

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,12 @@ if( NOT eckit_HAVE_LZ4 )
 endif()
 
 ecbuild_add_option( FEATURE RETRIEVE_ORCA_DATA
-                    DEFAULT OFF
+	                  DEFAULT OFF
                     DESCRIPTION "Retrieve all available atlas-orca binary data during build step." )
+
+ecbuild_add_option( FEATURE ORCA_IN_MEMORY_CACHE
+	                  DEFAULT OFF
+                    DESCRIPTION "Cache the orca data in order to avoid multiple loads from file" )
 
 # The above is equivalent to calling as part of build step:
 #
@@ -40,13 +44,12 @@ ecbuild_add_option( FEATURE RETRIEVE_ORCA_DATA
 #
 
 ecbuild_add_option( FEATURE INSTALL_ORCA_DATA
-                    DEFAULT OFF
+	                  DEFAULT OFF
                     DESCRIPTION "Install available atlas-orca binary data present in build dir" )
 
 atlas_create_plugin( atlas-orca
     URL       https://sites.ecmwf.int/docs/atlas
     NAMESPACE int.ecmwf )
-
 
 if( CMAKE_CXX_COMPILER_ID MATCHES NVHPC )
     ecbuild_add_cxx_flags("--diag_suppress declared_but_not_referenced --display_error_number" NAME atlas_orca_cxx_disable_warnings )

--- a/src/atlas-orca/CMakeLists.txt
+++ b/src/atlas-orca/CMakeLists.txt
@@ -10,85 +10,85 @@
 configure_file(version.cc.in version.cc)
 
 if ( HAVE_ORCA_IN_MEMORY_CACHE )
-ecbuild_add_library(
-    TARGET atlas-orca
-    TYPE SHARED
-    INSTALL_HEADERS LISTED
-    HEADER_DESTINATION "include/atlas-orca"
-    PUBLIC_DEFINITIONS
-        HAVE_ORCA_IN_MEMORY_CACHE
-    SOURCES 
-        Library.cc
-        Library.h
-        grid/Orca.cc
-        grid/Orca.h
-        grid/OrcaGrid.cc
-        grid/OrcaGrid.h
-        grid/OrcaGridBuilder.cc
-        meshgenerator/OrcaMeshGenerator.cc
-        meshgenerator/OrcaMeshGenerator.h
-        util/AtlasIOReader.h
-        util/ComputeCachedPath.h
-        util/ComputeUid.h
-        util/ComputeUid.cc
-        util/DetectInvalidElements.cc
-        util/DetectInvalidElements.h
-        util/Download.cc
-        util/Download.h
-        util/Enums.h
-        util/Flag.h
-        util/OrcaData.cc
-        util/OrcaData.h
-        util/OrcaDataFile.h
-        util/OrcaPeriodicity.cc
-        util/OrcaPeriodicity.h
-        util/PointIJ.h
-        ${CMAKE_CURRENT_BINARY_DIR}/version.cc
-        version.h
-    PUBLIC_LIBS atlas
-    PUBLIC_INCLUDES 
-       $<INSTALL_INTERFACE:include/atlas-orca>
-       $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
-       $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src> )
+    ecbuild_add_library(
+        TARGET atlas-orca
+        TYPE SHARED
+        INSTALL_HEADERS LISTED
+        HEADER_DESTINATION "include/atlas-orca"
+        PUBLIC_DEFINITIONS
+            HAVE_ORCA_IN_MEMORY_CACHE
+        SOURCES 
+            Library.cc
+            Library.h
+            grid/Orca.cc
+            grid/Orca.h
+            grid/OrcaGrid.cc
+            grid/OrcaGrid.h
+            grid/OrcaGridBuilder.cc
+            meshgenerator/OrcaMeshGenerator.cc
+            meshgenerator/OrcaMeshGenerator.h
+            util/AtlasIOReader.h
+            util/ComputeCachedPath.h
+            util/ComputeUid.h
+            util/ComputeUid.cc
+            util/DetectInvalidElements.cc
+            util/DetectInvalidElements.h
+            util/Download.cc
+            util/Download.h
+            util/Enums.h
+            util/Flag.h
+            util/OrcaData.cc
+            util/OrcaData.h
+            util/OrcaDataFile.h
+            util/OrcaPeriodicity.cc
+            util/OrcaPeriodicity.h
+            util/PointIJ.h
+            ${CMAKE_CURRENT_BINARY_DIR}/version.cc
+            version.h
+        PUBLIC_LIBS atlas
+        PUBLIC_INCLUDES 
+           $<INSTALL_INTERFACE:include/atlas-orca>
+           $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
+           $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src> )
 else()
-ecbuild_add_library(
-    TARGET atlas-orca
-    TYPE SHARED
-    INSTALL_HEADERS LISTED
-    HEADER_DESTINATION "include/atlas-orca"
-    SOURCES 
-        Library.cc
-        Library.h
-        grid/Orca.cc
-        grid/Orca.h
-        grid/OrcaGrid.cc
-        grid/OrcaGrid.h
-        grid/OrcaGridBuilder.cc
-        meshgenerator/OrcaMeshGenerator.cc
-        meshgenerator/OrcaMeshGenerator.h
-        util/AtlasIOReader.h
-        util/ComputeCachedPath.h
-        util/ComputeUid.h
-        util/ComputeUid.cc
-        util/DetectInvalidElements.cc
-        util/DetectInvalidElements.h
-        util/Download.cc
-        util/Download.h
-        util/Enums.h
-        util/Flag.h
-        util/OrcaData.cc
-        util/OrcaData.h
-        util/OrcaDataFile.h
-        util/OrcaPeriodicity.cc
-        util/OrcaPeriodicity.h
-        util/PointIJ.h
-        ${CMAKE_CURRENT_BINARY_DIR}/version.cc
-        version.h
-    PUBLIC_LIBS atlas
-    PUBLIC_INCLUDES 
-       $<INSTALL_INTERFACE:include/atlas-orca>
-       $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
-       $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src> )
+    ecbuild_add_library(
+        TARGET atlas-orca
+        TYPE SHARED
+        INSTALL_HEADERS LISTED
+        HEADER_DESTINATION "include/atlas-orca"
+        SOURCES 
+            Library.cc
+            Library.h
+            grid/Orca.cc
+            grid/Orca.h
+            grid/OrcaGrid.cc
+            grid/OrcaGrid.h
+            grid/OrcaGridBuilder.cc
+            meshgenerator/OrcaMeshGenerator.cc
+            meshgenerator/OrcaMeshGenerator.h
+            util/AtlasIOReader.h
+            util/ComputeCachedPath.h
+            util/ComputeUid.h
+            util/ComputeUid.cc
+            util/DetectInvalidElements.cc
+            util/DetectInvalidElements.h
+            util/Download.cc
+            util/Download.h
+            util/Enums.h
+            util/Flag.h
+            util/OrcaData.cc
+            util/OrcaData.h
+            util/OrcaDataFile.h
+            util/OrcaPeriodicity.cc
+            util/OrcaPeriodicity.h
+            util/PointIJ.h
+            ${CMAKE_CURRENT_BINARY_DIR}/version.cc
+            version.h
+        PUBLIC_LIBS atlas
+        PUBLIC_INCLUDES 
+           $<INSTALL_INTERFACE:include/atlas-orca>
+           $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
+           $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src> )
 endif()
 
 if( atlas_VERSION VERSION_GREATER_EQUAL 0.35.0 )

--- a/src/atlas-orca/CMakeLists.txt
+++ b/src/atlas-orca/CMakeLists.txt
@@ -9,6 +9,48 @@
 
 configure_file(version.cc.in version.cc)
 
+if ( HAVE_ORCA_IN_MEMORY_CACHE )
+ecbuild_add_library(
+    TARGET atlas-orca
+    TYPE SHARED
+    INSTALL_HEADERS LISTED
+    HEADER_DESTINATION "include/atlas-orca"
+    PUBLIC_DEFINITIONS
+        HAVE_ORCA_IN_MEMORY_CACHE
+    SOURCES 
+        Library.cc
+        Library.h
+        grid/Orca.cc
+        grid/Orca.h
+        grid/OrcaGrid.cc
+        grid/OrcaGrid.h
+        grid/OrcaGridBuilder.cc
+        meshgenerator/OrcaMeshGenerator.cc
+        meshgenerator/OrcaMeshGenerator.h
+        util/AtlasIOReader.h
+        util/ComputeCachedPath.h
+        util/ComputeUid.h
+        util/ComputeUid.cc
+        util/DetectInvalidElements.cc
+        util/DetectInvalidElements.h
+        util/Download.cc
+        util/Download.h
+        util/Enums.h
+        util/Flag.h
+        util/OrcaData.cc
+        util/OrcaData.h
+        util/OrcaDataFile.h
+        util/OrcaPeriodicity.cc
+        util/OrcaPeriodicity.h
+        util/PointIJ.h
+        ${CMAKE_CURRENT_BINARY_DIR}/version.cc
+        version.h
+    PUBLIC_LIBS atlas
+    PUBLIC_INCLUDES 
+       $<INSTALL_INTERFACE:include/atlas-orca>
+       $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
+       $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src> )
+else()
 ecbuild_add_library(
     TARGET atlas-orca
     TYPE SHARED
@@ -47,6 +89,7 @@ ecbuild_add_library(
        $<INSTALL_INTERFACE:include/atlas-orca>
        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src> )
+endif()
 
 if( atlas_VERSION VERSION_GREATER_EQUAL 0.35.0 )
     set( ATLAS_TEMPORARY_ELEMENTTYPES 0 )

--- a/src/atlas-orca/grid/Orca.cc
+++ b/src/atlas-orca/grid/Orca.cc
@@ -36,6 +36,10 @@ namespace grid {
 
 namespace {
 
+#if defined(HAVE_ORCA_IN_MEMORY_CACHE)
+static std::map<std::string,orca::OrcaData> ORCA_InMemoryCache;
+#endif
+
 static bool validate_uid() {
     static bool ATLAS_ORCA_VALIDATE_UID = bool(
         eckit::LibResource<bool, atlas::orca::Library>( "atlas-orca-validate-uid;$ATLAS_ORCA_VALIDATE_UID", false ) );
@@ -95,10 +99,20 @@ Orca::Orca( const std::string& name, const Config& config ) :
 
     orca::OrcaData data;
 
+#if defined(HAVE_ORCA_IN_MEMORY_CACHE)
+    std::string key = name_;
+    if ( ORCA_InMemoryCache.find(key) == ORCA_InMemoryCache.end() )
+#endif
     {
         // Read data
         orca::OrcaDataFile file{spec_.getString( "data" )};
         orca::AtlasIOReader{}.read( file, data );
+#if defined(HAVE_ORCA_IN_MEMORY_CACHE)
+        ORCA_InMemoryCache[key] = data;
+    }
+    else{
+        data = ORCA_InMemoryCache.at(key);
+#endif
     }
 
     halo_north_ = data.halo[orca::HALO_NORTH];


### PR DESCRIPTION
Still rude implementation. Some notes:

1) An std::map has been chosen over an std::unordered_map.  The reason is that this map is supposed to contain never more than 5 elements since the grid resolution remain constant during a simulation. In scenarios with a small number of elements like this, the computational cost associated with the hash algorithm in an unordered map can sometimes exceed the efficiency gains achieved through key-comparisons.  Open to discuss this point.

2) The CMakeFiles.txt may seem unwieldy with its extensive if-else structure. Unfortunately, finding a more elegant solution proved challenging. Open to suggestions for improvement in this area.

3) Although using pointers within the map could potentially improve performance by reducing the need for copies, implementing this change would require more extensive code modifications. For the sake of maintaining code stability, I decided against such invasive changes. Open to suggestions for improvement in this area.

I tested on my personal machine and this modification gives a 10% to 20% boost on pure interpolation timing.
We are still working to perform a benchmark with the full coupled simulation.