### PR TITLE
feature: Treat a "serial" distribution the same as a single partition

### DIFF
--- a/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
+++ b/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
@@ -296,8 +296,7 @@ void OrcaMeshGenerator::generate( const Grid& grid, const grid::Distribution& di
         return glbarray_offset + j * glbarray_jstride + i;
     };
 
-    std::string partitioner_name = distribution.type();
-    const bool serial_distribution = (nparts == 1 || partitioner_name == "serial");
+    const bool serial_distribution = (nparts == 1 || distribution.type() == "serial");
 
     auto partition = [&]( idx_t i, idx_t j ) -> int {
         if ( nparts == 1 ) {

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -40,3 +40,10 @@ ecbuild_add_test( TARGET  atlas_test_orca_polygon_locator
                   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
                   CONDITION eckit_HAVE_LZ4 AND eckit_HAVE_MPI)
 
+ecbuild_add_test( TARGET  atlas_test_orca_mesh_boundaries
+                  SOURCES test_orca_mesh_boundaries.cc
+                  LIBS    atlas-orca
+                  MPI     2
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+                  CONDITION eckit_HAVE_LZ4  AND eckit_HAVE_MPI)
+

--- a/src/tests/test_orca_mesh_boundaries.cc
+++ b/src/tests/test_orca_mesh_boundaries.cc
@@ -1,0 +1,92 @@
+/*
+ * (C) Copyright 2021- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include <numeric>
+
+#include "atlas/functionspace/NodeColumns.h"
+#include "atlas/grid.h"
+#include "atlas/mesh.h"
+#include "atlas/meshgenerator.h"
+#include "atlas/util/Config.h"
+#include "atlas/output/Gmsh.h"
+
+#include "atlas/util/Geometry.h"
+
+#include "atlas-orca/grid/OrcaGrid.h"
+
+#include "tests/AtlasTestEnvironment.h"
+
+using Grid   = atlas::Grid;
+using Config = atlas::util::Config;
+
+namespace atlas {
+namespace test {
+
+
+CASE( "test haloExchange " ) {
+    auto gridnames = std::vector<std::string>{
+        "ORCA2_T",   //
+        "eORCA1_T",  //
+        "eORCA025_T",  //
+    };
+    for ( auto gridname : gridnames ) {
+        for ( int64_t halo =0; halo < 2; ++halo ) {
+            SECTION( gridname + "_halo" + std::to_string(halo) ) {
+                auto grid = Grid(gridname);
+                auto meshgen_config = grid.meshgenerator() | option::halo(halo);
+                atlas::MeshGenerator meshgen(meshgen_config);
+                auto partitioner_config = grid.partitioner();
+                partitioner_config.set("type", "serial");
+                auto partitioner = grid::Partitioner(partitioner_config);
+                auto mesh = meshgen.generate(grid, partitioner);
+                REQUIRE( mesh.grid() );
+                EXPECT( mesh.grid().name() == gridname );
+                idx_t count{0};
+
+                const auto remote_idxs = array::make_indexview<idx_t, 1>(
+                                          mesh.nodes().remote_index());
+                functionspace::NodeColumns fs{mesh};
+                Field field   = fs.createField<double>( option::name( "unswapped ghosts" ) );
+                auto f        = array::make_view<double, 1>( field );
+                const auto ghosts = atlas::array::make_view<int32_t, 1>(
+                                      mesh.nodes().ghost());
+                for ( idx_t jnode = 0; jnode < mesh.nodes().size(); ++jnode ) {
+                    if (ghosts(jnode)) {
+                        f( jnode ) = 1;
+                    } else {
+                        f( jnode ) = 0;
+                    }
+                }
+
+                fs.haloExchange(field);
+
+                for ( idx_t jnode = 0; jnode < mesh.nodes().size(); ++jnode ) {
+                    if (f( jnode )) {
+                      ++count;
+                    }
+                }
+                if ( count != 0 ) {
+                    Log::info() << "To diagnose problem, uncomment mesh writing here: " << Here() << std::endl;
+                    //output::Gmsh gmsh(std::string("haloExchange_")+gridname+".msh",Config("coordinates","ij")|Config("info",true));
+                    //gmsh.write(mesh);
+                    //gmsh.write(field);
+                }
+                EXPECT_EQ( count, 0 );
+            }
+        }
+    }
+}
+
+}  // namespace test
+}  // namespace atlas
+
+int main( int argc, char** argv ) {
+    return atlas::test::run( argc, argv );
+}


### PR DESCRIPTION
### Description

The "serial" decomposition generates a full copy of the atlas mesh on each MPI process. The boundary/periodic conditions should be updated in the same way as for a single MPI process in this case. This change bypasses later changes to the remote indices that would be made during `atlas::mesh::actions::build_parallel_fields`, preserving the setup that is used for a single processor to guarantee the correct swaps at the periodic boundaries and the north fold.

### Impact

This should fix issues at the periodic boundaries of all ORCA grids for `nparts >1` to match `nparts == 1` when serial decomposition is used. However, there is still a little work to do to fix cases of `checkerboard` and `equal_regions` partitioners.

This is a requirement to hit operational performance benchmarks in the JEDI-based Observation Processing Application (JOPA) at the Met Office.

### Testing

- addition of a new ctest in `test_orca_mesh_boundaries`. For now, this only tests this one case of 2 MPI processes and the serial distribution, but in the future I would like to add tests for other distributions too
- tested at the Met Office as a component in JOPA