### PR TITLE
Feature/eckit codec

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,12 @@ find_package(eckit 1.16.1 REQUIRED)
 find_package(atlas 0.25.0 REQUIRED)
 
 if( NOT eckit_HAVE_LZ4 )
-    ecbuild_warn( "eckit is required to have LZ4 support to decompress atlas-orca binary data files. "
+    ecbuild_warn( "eckit LZ4 support is required to decompress atlas-orca binary data files. "
                   "Continuing regardless with reduced tests" )
+endif()
+
+if( NOT TARGET eckit_codec )
+    ecbuild_error( "eckit::codec is required (ENABLE_ECKIT_CODEC=ON)" )
 endif()
 
 ecbuild_add_option( FEATURE RETRIEVE_ORCA_DATA

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,10 +22,6 @@ if( NOT eckit_HAVE_LZ4 )
                   "Continuing regardless with reduced tests" )
 endif()
 
-if( NOT TARGET eckit_codec )
-    ecbuild_error( "eckit::codec is required (ENABLE_ECKIT_CODEC=ON)" )
-endif()
-
 ecbuild_add_option( FEATURE RETRIEVE_ORCA_DATA
                     DEFAULT OFF
                     DESCRIPTION "Retrieve all available atlas-orca binary data during build step." )

--- a/src/apps/atlas-orca-cache.cc
+++ b/src/apps/atlas-orca-cache.cc
@@ -8,20 +8,20 @@
  * nor does it submit to any jurisdiction.
  */
 
+
 #include <iostream>
-#include <sstream>
+#include <vector>
+#include <set>
 #include <string>
 
-
-#include "eckit/filesystem/PathName.h"
+#include "eckit/codec/codec.h"
 
 #include "atlas/runtime/AtlasTool.h"
-#include "atlas/runtime/Exception.h"
 
+#include "atlas-orca/Library.h"
 #include "atlas-orca/util/ComputeCachedPath.h"
 #include "atlas-orca/util/Download.h"
 
-#include "atlas/io/atlas-io.h"
 
 namespace atlas {
 namespace orca {
@@ -30,7 +30,7 @@ namespace orca {
 
 struct Tool : public atlas::AtlasTool {
     bool serial() override { return true; }
-    int execute( const Args& args ) override;
+    int execute( const Args&  ) override;
     std::string briefDescription() override { return "Create binary grid data files "; }
     std::string usage() override { return name() + " <file> --grid=NAME [OPTION]... [--help,-h]"; }
     std::string longDescription() override {
@@ -80,7 +80,7 @@ int Tool::execute( const Args& args ) {
         {"https://get.ecmwf.int/repository/atlas/grids/orca", "http://get.ecmwf.int/repository/atlas/grids/orca"} );
 
     std::vector<std::string> failed_urls;
-    for ( auto& url : urls ) {
+    for ( const auto& url : urls ) {
         auto path = compute_cached_path( url );
         if ( path.exists() ) {
             Log::info() << "File " << url << " was already found in cache: " << path << std::endl;
@@ -92,10 +92,10 @@ int Tool::execute( const Args& args ) {
             }
             else {
                 try {
-                    io::RecordReader record( path );
+                    eckit::codec::RecordReader record( path );
                     auto metadata = record.metadata( "dimensions" );
                 }
-                catch ( const io::InvalidRecord& ) {
+                catch ( const eckit::codec::InvalidRecord& ) {
                     Log::error() << "Error: Downloaded file " << path << " is invalid. Deleting...\n" << std::endl;
                     path.unlink( true );
                     failed_urls.push_back( url );

--- a/src/apps/atlas-orca-cache.cc
+++ b/src/apps/atlas-orca-cache.cc
@@ -10,9 +10,9 @@
 
 
 #include <iostream>
-#include <vector>
 #include <set>
 #include <string>
+#include <vector>
 
 #include "eckit/codec/codec.h"
 
@@ -30,7 +30,7 @@ namespace orca {
 
 struct Tool : public atlas::AtlasTool {
     bool serial() override { return true; }
-    int execute( const Args&  ) override;
+    int execute( const Args& ) override;
     std::string briefDescription() override { return "Create binary grid data files "; }
     std::string usage() override { return name() + " <file> --grid=NAME [OPTION]... [--help,-h]"; }
     std::string longDescription() override {
@@ -77,7 +77,7 @@ int Tool::execute( const Args& args ) {
         }
     }
     ComputeCachedPath compute_cached_path(
-        {"https://get.ecmwf.int/repository/atlas/grids/orca", "http://get.ecmwf.int/repository/atlas/grids/orca"} );
+        { "https://get.ecmwf.int/repository/atlas/grids/orca", "http://get.ecmwf.int/repository/atlas/grids/orca" } );
 
     std::vector<std::string> failed_urls;
     for ( const auto& url : urls ) {

--- a/src/apps/atlas-orca-cache.cc
+++ b/src/apps/atlas-orca-cache.cc
@@ -14,7 +14,16 @@
 #include <string>
 #include <vector>
 
+#if ATLAS_ORCA_HAVE_ECKIT_CODEC
 #include "eckit/codec/codec.h"
+#else
+// Backward compatibility, DEPRECATED!
+#include "atlas/io/atlas-io.h"
+namespace eckit::codec {
+using RecordReader = atlas::io::RecordReader;
+using InvalidRecord = atlas::io::InvalidRecord;
+}
+#endif
 
 #include "atlas/runtime/AtlasTool.h"
 

--- a/src/apps/atlas-orca-cache.cc
+++ b/src/apps/atlas-orca-cache.cc
@@ -23,8 +23,7 @@
 #include "atlas-orca/util/Download.h"
 
 
-namespace atlas {
-namespace orca {
+namespace atlas::orca {
 
 //----------------------------------------------------------------------------------------------------------------------
 
@@ -113,8 +112,8 @@ int Tool::execute( const Args& args ) {
     return success();
 }
 
-}  // namespace orca
-}  // namespace atlas
+}  // namespace atlas::orca
+
 
 //------------------------------------------------------------------------------------------------------
 

--- a/src/apps/atlas-orca-convert/AsciiReader.h
+++ b/src/apps/atlas-orca-convert/AsciiReader.h
@@ -102,8 +102,8 @@ struct ReadLine {
 
 class AsciiReader {
 private:
-    bool verbose_{false};
-    int version_{2};
+    bool verbose_{ false };
+    int version_{ 2 };
     std::vector<double> pivot_v1_;
 
 public:
@@ -114,21 +114,21 @@ public:
     }
 
     void read( const std::string& uri, OrcaData& data ) {
-        OrcaDataFile file{uri};
+        OrcaDataFile file{ uri };
 
         auto trace = atlas::Trace( Here(), "read" );
 
-        std::ifstream ifstrm{file.c_str()};
+        std::ifstream ifstrm{ file.c_str() };
 
         // Reading header
         std::string line;
         std::getline( ifstrm, line );
-        std::istringstream iss{line};
+        std::istringstream iss{ line };
 
         std::int32_t nx_halo = 0;
         std::int32_t ny_halo = 0;
         auto& halo           = data.halo;
-        halo                 = {0, 0, 0, 0};
+        halo                 = { 0, 0, 0, 0 };
 
         ATLAS_ASSERT( iss >> nx_halo >> ny_halo, "Error while reading header" );
         if ( version_ == 1 ) {
@@ -164,14 +164,14 @@ public:
                 ++progress;
                 master[n] = n;
                 std::getline( ifstrm, line );
-                std::istringstream iss{line};
+                std::istringstream iss{ line };
                 iss >> r;
                 r.fix();
 
                 data.lon[n] = r.lon;
                 data.lat[n] = r.lat;
 
-                Flag flag{data.flags[n]};
+                Flag flag{ data.flags[n] };
                 if ( r.core == 0. ) {  // ghost
                     flag.set( Flag::GHOST );
                     if ( version_ >= 2 ) {
@@ -269,7 +269,7 @@ public:
         constexpr int E = HALO_EAST;
         auto& halo      = data.halo;
 
-        OrcaPeriodicity compute_master{data};
+        OrcaPeriodicity compute_master{ data };
 
         Log::info() << "pivot_i = " << data.pivot[0] << std::endl;
         Log::info() << "pivot_j = " << data.pivot[1] << std::endl;
@@ -280,7 +280,7 @@ public:
             for ( idx_t i = 0; i < ni; ++i ) {
                 auto master = compute_master( i, j );
                 idx_t n     = ni * j + i;
-                Flag flag{data.flags[n]};
+                Flag flag{ data.flags[n] };
 
                 if ( j < halo[S] || j >= nj - halo[N] ) {
                     ATLAS_ASSERT( flag.test( Flag::GHOST ) );

--- a/src/apps/atlas-orca-convert/NetCDFReader.cc
+++ b/src/apps/atlas-orca-convert/NetCDFReader.cc
@@ -26,8 +26,8 @@
 #include "atlas-orca/util/Enums.h"
 #include "atlas-orca/util/Flag.h"
 
-namespace atlas {
-namespace orca {
+
+namespace atlas::orca {
 
 NetCDFReader::NetCDFReader( const util::Config& config ) {
     config.get( "arrangement", arrangement_ );
@@ -61,7 +61,8 @@ void NetCDFReader::read( const std::string& uri, OrcaData& data ) {
         if ( var.isNull() ) {
             ATLAS_THROW_EXCEPTION( "Variable '" << name << "' is not present in NetCDF file" );
         }
-        size_t ni, nj;
+        size_t ni = 0;
+        size_t nj = 0;
         read_dimensions( ni, nj );
         auto dims = var.getDims();
         values.resize( ni * nj );
@@ -86,11 +87,12 @@ void NetCDFReader::read( const std::string& uri, OrcaData& data ) {
         }
     };
 
-    size_t ni, nj;
+    size_t ni     = 0;
+    size_t nj     = 0;
     std::string P = arrangement_;
     ATLAS_ASSERT( P.size() == 1 );
     std::string p = P;
-    p[0]          = ( P == "W" ) ? 't' : std::tolower( P[0] );
+    p[0]          = ( P == "W" ) ? 't' : static_cast<char>( std::tolower( P[0] ) );
     std::vector<double> mask;
 
     read_dimensions( ni, nj );
@@ -98,7 +100,7 @@ void NetCDFReader::read( const std::string& uri, OrcaData& data ) {
     read_variable( "gphi" + p, data.lat );
     read_variable( p + "mask", mask );
 
-    data.dimensions = { int( ni ), int( nj ) };
+    data.dimensions = { static_cast<int>( ni ), static_cast<int>( nj ) };
     data.flags.resize( ni * nj );
     for ( size_t n = 0; n < data.flags.size(); ++n ) {
         Flag flag{ data.flags[n] };
@@ -109,10 +111,10 @@ void NetCDFReader::read( const std::string& uri, OrcaData& data ) {
 
     data.halo[HALO_EAST] = 1;
     data.halo[HALO_WEST] = 1;
-    eckit::Fraction resolution{ 360, int( ni ) - data.halo[HALO_EAST] - data.halo[HALO_WEST] };
+    eckit::Fraction resolution{ 360, static_cast<int>( ni ) - data.halo[HALO_EAST] - data.halo[HALO_WEST] };
     if ( resolution != 1. ) {
         // T-pivot
-        data.pivot = { double( ni / 2 ), double( nj - 2 ) };
+        data.pivot = { static_cast<double>( ni / 2 ), static_cast<double>( nj - 2 ) };
         if ( P == "T" || P == "W" ) {
             data.halo[HALO_NORTH] = 1;
             data.halo[HALO_SOUTH] = 1;
@@ -139,7 +141,7 @@ void NetCDFReader::read( const std::string& uri, OrcaData& data ) {
     }
     else {
         // F-pivot
-        data.pivot = { double( ni / 2 - 1 ), double( nj - 2 ) };
+        data.pivot = { static_cast<double>( ni / 2 - 1 ), static_cast<double>( nj - 2 ) };
         if ( P == "T" || P == "W" ) {
             data.halo[HALO_NORTH] = 1;
             data.halo[HALO_SOUTH] = 1;
@@ -170,5 +172,4 @@ void NetCDFReader::read( const std::string& uri, OrcaData& data ) {
 #endif
 }
 
-}  // namespace orca
-}  // namespace atlas
+}  // namespace atlas::orca

--- a/src/apps/atlas-orca-convert/NetCDFReader.cc
+++ b/src/apps/atlas-orca-convert/NetCDFReader.cc
@@ -41,7 +41,7 @@ void NetCDFReader::read( const std::string& uri, OrcaData& data ) {
 #if ATLAS_ORCA_HAVE_NETCDF == 0
     ATLAS_THROW_EXCEPTION( "atlas-orca was not compiled with NetCDF support" );
 #else
-    OrcaDataFile file{uri};
+    OrcaDataFile file{ uri };
 
     netCDF::NcFile ncdata( file, netCDF::NcFile::read );
     auto read_dimensions = [&]( size_t& ni, size_t& nj ) {
@@ -68,12 +68,12 @@ void NetCDFReader::read( const std::string& uri, OrcaData& data ) {
         if ( dims.size() == 3 ) {
             ATLAS_ASSERT( dims[1].getSize() == nj );
             ATLAS_ASSERT( dims[2].getSize() == ni );
-            var.getVar( {0, 0, 0}, {1, nj, ni}, values.data() );
+            var.getVar( { 0, 0, 0 }, { 1, nj, ni }, values.data() );
         }
         else if ( dims.size() == 4 ) {
             ATLAS_ASSERT( dims[2].getSize() == nj );
             ATLAS_ASSERT( dims[3].getSize() == ni );
-            var.getVar( {0, 0, 0, 0}, {1, 1, nj, ni}, values.data() );
+            var.getVar( { 0, 0, 0, 0 }, { 1, 1, nj, ni }, values.data() );
         }
         else {
             std::stringstream errmsg;
@@ -98,10 +98,10 @@ void NetCDFReader::read( const std::string& uri, OrcaData& data ) {
     read_variable( "gphi" + p, data.lat );
     read_variable( p + "mask", mask );
 
-    data.dimensions = {int( ni ), int( nj )};
+    data.dimensions = { int( ni ), int( nj ) };
     data.flags.resize( ni * nj );
     for ( size_t n = 0; n < data.flags.size(); ++n ) {
-        Flag flag{data.flags[n]};
+        Flag flag{ data.flags[n] };
         if ( mask[n] != 0. ) {
             flag.set( Flag::WATER );
         }
@@ -109,10 +109,10 @@ void NetCDFReader::read( const std::string& uri, OrcaData& data ) {
 
     data.halo[HALO_EAST] = 1;
     data.halo[HALO_WEST] = 1;
-    eckit::Fraction resolution{360, int( ni ) - data.halo[HALO_EAST] - data.halo[HALO_WEST]};
+    eckit::Fraction resolution{ 360, int( ni ) - data.halo[HALO_EAST] - data.halo[HALO_WEST] };
     if ( resolution != 1. ) {
         // T-pivot
-        data.pivot = {double( ni / 2 ), double( nj - 2 )};
+        data.pivot = { double( ni / 2 ), double( nj - 2 ) };
         if ( P == "T" || P == "W" ) {
             data.halo[HALO_NORTH] = 1;
             data.halo[HALO_SOUTH] = 1;
@@ -139,7 +139,7 @@ void NetCDFReader::read( const std::string& uri, OrcaData& data ) {
     }
     else {
         // F-pivot
-        data.pivot = {double( ni / 2 - 1 ), double( nj - 2 )};
+        data.pivot = { double( ni / 2 - 1 ), double( nj - 2 ) };
         if ( P == "T" || P == "W" ) {
             data.halo[HALO_NORTH] = 1;
             data.halo[HALO_SOUTH] = 1;

--- a/src/apps/atlas-orca-convert/NetCDFReader.h
+++ b/src/apps/atlas-orca-convert/NetCDFReader.h
@@ -34,7 +34,7 @@ public:
     void read( const std::string& uri, OrcaData& data );
 
 private:
-    std::string arrangement_{"T"};
+    std::string arrangement_{ "T" };
 };
 
 }  // namespace orca

--- a/src/apps/atlas-orca-convert/NetCDFReader.h
+++ b/src/apps/atlas-orca-convert/NetCDFReader.h
@@ -24,20 +24,20 @@
 #include "atlas-orca/util/OrcaData.h"
 #include "atlas-orca/util/OrcaDataFile.h"
 
-namespace atlas {
-namespace orca {
+
+namespace atlas::orca {
 
 class NetCDFReader {
 public:
-    NetCDFReader( const util::Config& config = util::NoConfig() );
+    explicit NetCDFReader( const util::Config& = util::NoConfig() );
 
-    void read( const std::string& uri, OrcaData& data );
+    void read( const std::string& uri, OrcaData& );
 
 private:
     std::string arrangement_{ "T" };
 };
 
-}  // namespace orca
-}  // namespace atlas
+}  // namespace atlas::orca
+
 
 //------------------------------------------------------------------------------------------------------

--- a/src/apps/atlas-orca-convert/atlas-orca-convert.cc
+++ b/src/apps/atlas-orca-convert/atlas-orca-convert.cc
@@ -28,8 +28,8 @@
 #include "atlas-orca/util/AtlasIOReader.h"
 #include "atlas-orca/util/OrcaData.h"
 
-namespace atlas {
-namespace orca {
+
+namespace atlas::orca {
 
 //----------------------------------------------------------------------------------------------------------------------
 
@@ -168,7 +168,8 @@ int Tool::execute( const Args& args ) {
     if ( not yaml_output ) {
         ATLAS_TRACE( "Write data file" );
         auto length = data.write( outputfile, args );
-        Log::info() << "Written " << eckit::Bytes( length ) << " to file " << outputfile << std::endl;
+        Log::info() << "Written " << eckit::Bytes( static_cast<double>( length ) ) << " to file " << outputfile
+                    << std::endl;
     }
 
     if ( yaml_output ) {
@@ -187,8 +188,8 @@ int Tool::execute( const Args& args ) {
     return success();
 }
 
-}  // namespace orca
-}  // namespace atlas
+}  // namespace atlas::orca
+
 
 //------------------------------------------------------------------------------------------------------
 

--- a/src/apps/atlas-orca-convert/atlas-orca-convert.cc
+++ b/src/apps/atlas-orca-convert/atlas-orca-convert.cc
@@ -80,7 +80,7 @@ int Tool::execute( const Args& args ) {
         help( std::cout );
         return failed();
     }
-    std::string input{args( 0 )};
+    std::string input{ args( 0 ) };
     if ( input.find( "http" ) != 0 ) {
         eckit::PathName file( input );
         if ( !file.exists() ) {
@@ -120,7 +120,7 @@ int Tool::execute( const Args& args ) {
     OrcaData data;
 
     if ( input_format.find( "netcdf" ) == 0 ) {
-        NetCDFReader{args}.read( input, data );
+        NetCDFReader{ args }.read( input, data );
     }
     else if ( input_format.find( "ascii-v" ) == 0 ) {
         std::string version_str = input_format.substr( 7 );
@@ -131,7 +131,7 @@ int Tool::execute( const Args& args ) {
         reader.read( input, data );
     }
     else if ( input_format == "atlas-io" ) {
-        AtlasIOReader{util::NoConfig()}.read( input, data );
+        AtlasIOReader{ util::NoConfig() }.read( input, data );
     }
     else {
         Log::warning() << "Unknown input_format \"" << input_format << "\"" << std::endl;
@@ -150,11 +150,11 @@ int Tool::execute( const Args& args ) {
         const int halo_E = data.halo[HALO_EAST];
         int nx           = data.dimensions[0] - halo_W - halo_E;
 
-        Log::info() << "resolution       : " << eckit::Fraction{360, nx} << " degrees" << std::endl;
-        Log::info() << "dimensions       : "
-                    << "[" << data.dimensions[0] << "," << data.dimensions[1] << "]" << std::endl;
-        Log::info() << "halo [N,W,S,E]   : "
-                    << "[" << halo_N << "," << halo_W << "," << halo_S << "," << halo_E << "]" << std::endl;
+        Log::info() << "resolution       : " << eckit::Fraction{ 360, nx } << " degrees" << std::endl;
+        Log::info() << "dimensions       : " << "[" << data.dimensions[0] << "," << data.dimensions[1] << "]"
+                    << std::endl;
+        Log::info() << "halo [N,W,S,E]   : " << "[" << halo_N << "," << halo_W << "," << halo_S << "," << halo_E << "]"
+                    << std::endl;
         Log::info() << "invalid elements : " << invalid_element_statistics.invalid_elements << std::endl;
         if ( invalid_element_statistics.invalid_elements > 0 ) {
             Log::info() << "    quad2d       : " << invalid_element_statistics.invalid_quads_2d << std::endl;

--- a/src/atlas-orca/CMakeLists.txt
+++ b/src/atlas-orca/CMakeLists.txt
@@ -43,7 +43,7 @@ ecbuild_add_library(
         util/PointIJ.h
         ${CMAKE_CURRENT_BINARY_DIR}/version.cc
         version.h
-    PUBLIC_LIBS atlas eckit_codec
+    PUBLIC_LIBS atlas
     PUBLIC_INCLUDES 
        $<INSTALL_INTERFACE:include/atlas-orca>
        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
@@ -59,4 +59,13 @@ set_source_files_properties( meshgenerator/OrcaMeshGenerator.cc PROPERTIES COMPI
 if (eckit_HAVE_CURL)
     set_source_files_properties( util/Download.cc
                             PROPERTIES COMPILE_DEFINITIONS "ATLAS_ORCA_HAVE_ECKIT_URLHANDLE")
+endif()
+
+if( TARGET eckit_codec )
+  target_link_libraries(atlas-orca PUBLIC eckit_codec)
+  target_compile_definitions(atlas-orca PUBLIC ATLAS_ORCA_HAVE_ECKIT_CODEC=1)
+  ecbuild_info("atlas-orca is using eckit_codec")
+else()
+  target_compile_definitions(atlas-orca PUBLIC ATLAS_ORCA_HAVE_ECKIT_CODEC=0)
+  ecbuild_info("atlas-orca is using atlas_io as eckit is not compiled with eckit_codec")
 endif()

--- a/src/atlas-orca/CMakeLists.txt
+++ b/src/atlas-orca/CMakeLists.txt
@@ -42,7 +42,7 @@ ecbuild_add_library(
         util/PointIJ.h
         ${CMAKE_CURRENT_BINARY_DIR}/version.cc
         version.h
-    PUBLIC_LIBS atlas
+    PUBLIC_LIBS atlas eckit_codec
     PUBLIC_INCLUDES 
        $<INSTALL_INTERFACE:include/atlas-orca>
        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>

--- a/src/atlas-orca/CMakeLists.txt
+++ b/src/atlas-orca/CMakeLists.txt
@@ -36,6 +36,7 @@ ecbuild_add_library(
         util/Flag.h
         util/OrcaData.cc
         util/OrcaData.h
+        util/OrcaDataFile.cc
         util/OrcaDataFile.h
         util/OrcaPeriodicity.cc
         util/OrcaPeriodicity.h

--- a/src/atlas-orca/Library.cc
+++ b/src/atlas-orca/Library.cc
@@ -10,13 +10,13 @@
 
 #include <string>
 
-#include "eckit/config/Resource.h"
-#include "eckit/filesystem/PathName.h"
-#include "eckit/runtime/Main.h"
 #include "atlas-orca/Library.h"
 #include "atlas-orca/version.h"
 #include "atlas/grid/SpecRegistry.h"
 #include "atlas/library/Library.h"
+#include "eckit/config/Resource.h"
+#include "eckit/filesystem/PathName.h"
+#include "eckit/runtime/Main.h"
 
 
 namespace atlas {
@@ -67,7 +67,7 @@ bool Library::caching() const {
 }
 
 std::string Library::dataPath() const {
-    return atlas::Library::instance().dataPath()+":~atlas-orca/share";
+    return atlas::Library::instance().dataPath() + ":~atlas-orca/share";
 }
 
 std::string Library::cachePath() const {
@@ -75,8 +75,8 @@ std::string Library::cachePath() const {
 }
 
 std::string Library::gridsPath() const {
-    static std::string ATLAS_ORCA_GRIDS_PATH = eckit::LibResource<std::string, atlas::orca::Library>(
-        "atlas-orca-grids-path;$ATLAS_ORCA_GRIDS_PATH", "" );
+    static std::string ATLAS_ORCA_GRIDS_PATH =
+        eckit::LibResource<std::string, atlas::orca::Library>( "atlas-orca-grids-path;$ATLAS_ORCA_GRIDS_PATH", "" );
     ATLAS_ASSERT( not ATLAS_ORCA_GRIDS_PATH.empty() );
     return ATLAS_ORCA_GRIDS_PATH;
 }

--- a/src/atlas-orca/Library.cc
+++ b/src/atlas-orca/Library.cc
@@ -24,8 +24,7 @@ class Grid;
 }
 
 
-namespace atlas {
-namespace orca {
+namespace atlas::orca {
 
 
 REGISTER_LIBRARY( Library );
@@ -81,5 +80,4 @@ std::string Library::gridsPath() const {
     return ATLAS_ORCA_GRIDS_PATH;
 }
 
-}  // namespace orca
-}  // namespace atlas
+}  // namespace atlas::orca

--- a/src/atlas-orca/Library.h
+++ b/src/atlas-orca/Library.h
@@ -12,8 +12,8 @@
 
 #include "atlas/library/Plugin.h"
 
-namespace atlas {
-namespace orca {
+
+namespace atlas::orca {
 
 
 class Library : public Plugin {
@@ -32,5 +32,4 @@ public:
 };
 
 
-}  // namespace orca
-}  // namespace atlas
+}  // namespace atlas::orca

--- a/src/atlas-orca/grid/Orca.cc
+++ b/src/atlas-orca/grid/Orca.cc
@@ -97,7 +97,7 @@ Orca::Orca( const std::string& name, const Config& config ) :
 
     {
         // Read data
-        orca::OrcaDataFile file{spec_.getString( "data" )};
+        orca::OrcaDataFile file{ spec_.getString( "data" ) };
         orca::AtlasIOReader{}.read( file, data );
     }
 
@@ -118,7 +118,7 @@ Orca::Orca( const std::string& name, const Config& config ) :
     ghost_.resize( nx_halo_ * ny_halo_ );
     invalid_element_.resize( nx_halo_ * ny_halo_ );
 
-    size_t nn{0};
+    size_t nn{ 0 };
     for ( idx_t j = 0; j < ny_halo_; ++j ) {
         for ( idx_t i = 0; i < nx_halo_; ++i, ++nn ) {
             gidx_t n = j * jstride_ + i;

--- a/src/atlas-orca/grid/Orca.h
+++ b/src/atlas-orca/grid/Orca.h
@@ -74,13 +74,13 @@ private:
             jend_( grid.ny() + grid.haloNorth() ),
             i_( -grid.haloWest() ),
             j_( -grid.haloSouth() ),
-            compute_point_{grid_} {
+            compute_point_{ grid_ } {
             if ( not begin ) {
                 i_ = ibegin_;
                 j_ = jend_;
             }
-            if( j_ != jend_ && i_ < iend_ ) {
-                compute_point_(i_, j_, point_);
+            if ( j_ != jend_ && i_ < iend_ ) {
+                compute_point_( i_, j_, point_ );
             }
         }
 
@@ -104,8 +104,8 @@ private:
                 ++j_;
                 i_ = ibegin_;
             }
-            if( j_ != jend_ && i_ < iend_ ) {
-                compute_point_(i_, j_, point_);
+            if ( j_ != jend_ && i_ < iend_ ) {
+                compute_point_( i_, j_, point_ );
             }
             return *this;
         }
@@ -119,8 +119,8 @@ private:
                 i_ = ibegin_;
             }
             i_ += d;
-            if( j_ != jend_ && i_ < iend_ ) {
-                compute_point_(i_, j_, point_);
+            if ( j_ != jend_ && i_ < iend_ ) {
+                compute_point_( i_, j_, point_ );
             }
             return *this;
         }

--- a/src/atlas-orca/grid/Orca.h
+++ b/src/atlas-orca/grid/Orca.h
@@ -29,15 +29,13 @@ namespace eckit {
 class PathName;
 }
 
-namespace atlas {
-namespace grid {
-namespace detail {
-namespace grid {
+
+namespace atlas::grid::detail::grid {
 
 class Orca final : public Grid {
 private:
     struct ComputePointXY {
-        ComputePointXY( const Orca& grid ) : grid_( grid ) {}
+        explicit ComputePointXY( const Orca& grid ) : grid_( grid ) {}
 
         void operator()( idx_t i, idx_t j, PointXY& point ) { grid_.xy( i, j, point.data() ); }
 
@@ -45,7 +43,7 @@ private:
     };
 
     struct ComputePointLonLat {
-        ComputePointLonLat( const Orca& grid ) : grid_( grid ) {}
+        explicit ComputePointLonLat( const Orca& grid ) : grid_( grid ) {}
 
         void operator()( idx_t i, idx_t j, PointLonLat& point ) { grid_.lonlat( i, j, point.data() ); }
 
@@ -54,7 +52,6 @@ private:
 
     template <typename Base, typename ComputePoint>
     class OrcaIterator : public Base {
-    protected:
         const Orca& grid_;
         idx_t ibegin_;
         idx_t iend_;
@@ -66,7 +63,7 @@ private:
         ComputePoint compute_point_;
 
     public:
-        OrcaIterator( const Orca& grid, bool begin = true ) :
+        explicit OrcaIterator( const Orca& grid, bool begin = true ) :
             grid_( grid ),
             ibegin_( -grid.haloWest() ),
             iend_( grid.nx() + grid.haloEast() ),
@@ -163,7 +160,7 @@ public:  // methods
     static std::string static_type();
 
     /// Constructor taking a configuration (spec)
-    Orca( const Config& );
+    explicit Orca( const Config& );
 
     /// Constructor taking a name/uid and a configuration (spec)
     Orca( const std::string& name_or_uid, const Config& );
@@ -202,21 +199,21 @@ public:
 
     void index2ij( gidx_t gidx, idx_t& i, idx_t& j ) const {
         //gidx = jstride_ * (jmin_+j) + (imin_+i);
-        j = gidx / jstride_ - jmin_;
-        i = gidx - ( jstride_ * ( j + jmin_ ) ) - imin_;
+        j = static_cast<idx_t>( gidx / jstride_ - jmin_ );
+        i = static_cast<idx_t>( gidx - ( jstride_ * ( j + jmin_ ) ) - imin_ );
     }
 
 
-    virtual std::unique_ptr<Grid::IteratorXY> xy_begin() const override {
+    std::unique_ptr<Grid::IteratorXY> xy_begin() const override {
         return std::unique_ptr<Grid::IteratorXY>( new IteratorXY( *this ) );
     }
-    virtual std::unique_ptr<Grid::IteratorXY> xy_end() const override {
+    std::unique_ptr<Grid::IteratorXY> xy_end() const override {
         return std::unique_ptr<Grid::IteratorXY>( new IteratorXY( *this, false ) );
     }
-    virtual std::unique_ptr<Grid::IteratorLonLat> lonlat_begin() const override {
+    std::unique_ptr<Grid::IteratorLonLat> lonlat_begin() const override {
         return std::unique_ptr<Grid::IteratorLonLat>( new IteratorLonLat( *this ) );
     }
-    virtual std::unique_ptr<Grid::IteratorLonLat> lonlat_end() const override {
+    std::unique_ptr<Grid::IteratorLonLat> lonlat_end() const override {
         return std::unique_ptr<Grid::IteratorLonLat>( new IteratorLonLat( *this, false ) );
     }
 
@@ -253,6 +250,8 @@ private:
     idx_t halo_north_;
     idx_t nx_halo_;
     idx_t ny_halo_;
+
+    /// Indices
     idx_t imin_;
     idx_t jmin_;
     idx_t istride_;
@@ -271,7 +270,4 @@ private:
 };
 
 
-}  // namespace grid
-}  // namespace detail
-}  // namespace grid
-}  // namespace atlas
+}  // namespace atlas::grid::detail::grid

--- a/src/atlas-orca/grid/OrcaGrid.cc
+++ b/src/atlas-orca/grid/OrcaGrid.cc
@@ -20,8 +20,8 @@ inline const OrcaGrid::grid_t* orca_grid( const Grid::Implementation* grid ) {
 
 OrcaGrid::OrcaGrid() : Grid() {}
 
-OrcaGrid::OrcaGrid( const std::string& name ) : Grid{name}, grid_{orca_grid( Grid::get() )} {}
+OrcaGrid::OrcaGrid( const std::string& name ) : Grid{ name }, grid_{ orca_grid( Grid::get() ) } {}
 
-OrcaGrid::OrcaGrid( const Grid& grid ) : Grid{grid}, grid_{orca_grid( Grid::get() )} {}
+OrcaGrid::OrcaGrid( const Grid& grid ) : Grid{ grid }, grid_{ orca_grid( Grid::get() ) } {}
 
 }  // namespace atlas

--- a/src/atlas-orca/grid/OrcaGrid.cc
+++ b/src/atlas-orca/grid/OrcaGrid.cc
@@ -18,7 +18,7 @@ inline const OrcaGrid::grid_t* orca_grid( const Grid::Implementation* grid ) {
     return dynamic_cast<const OrcaGrid::grid_t*>( grid );
 }
 
-OrcaGrid::OrcaGrid() : Grid() {}
+OrcaGrid::OrcaGrid() = default;
 
 OrcaGrid::OrcaGrid( const std::string& name ) : Grid{ name }, grid_{ orca_grid( Grid::get() ) } {}
 

--- a/src/atlas-orca/grid/OrcaGrid.h
+++ b/src/atlas-orca/grid/OrcaGrid.h
@@ -27,8 +27,8 @@ public:
     OrcaGrid( const std::string& name );
     OrcaGrid( const Grid& );
 
-    bool valid() const { return grid_; }
-    operator bool() const { return valid(); }
+    bool valid() const { return grid_ != nullptr; }
+    explicit operator bool() const { return valid(); }
 
     idx_t ny() const { return grid_->ny(); }
     idx_t nx() const { return grid_->nx(); }

--- a/src/atlas-orca/grid/OrcaGridBuilder.cc
+++ b/src/atlas-orca/grid/OrcaGridBuilder.cc
@@ -33,7 +33,8 @@ static class OrcaGridBuilder : public GridBuilder {
     using Config         = Grid::Config;
 
 public:
-    OrcaGridBuilder() : GridBuilder( Orca::static_type(), {"^e?ORCA[0-9]+_[FTUVW]$"}, {"[e]ORCA<deg>_{F,T,U,V,W}"} ) {}
+    OrcaGridBuilder() :
+        GridBuilder( Orca::static_type(), { "^e?ORCA[0-9]+_[FTUVW]$" }, { "[e]ORCA<deg>_{F,T,U,V,W}" } ) {}
 
     void print( std::ostream& os ) const override {
         os << std::left << std::setw( 30 ) << "[e]ORCA<deg>_{F,T,U,V,W}"
@@ -63,8 +64,8 @@ public:
 
     const Implementation* create( const Config& config ) const override {
         std::string type;
-        config.get("type",type);
-        if (type != "ORCA") {
+        config.get( "type", type );
+        if ( type != "ORCA" ) {
             return nullptr;
         }
         return new Orca( config );

--- a/src/atlas-orca/grid/OrcaGridBuilder.cc
+++ b/src/atlas-orca/grid/OrcaGridBuilder.cc
@@ -22,10 +22,8 @@
 #include "atlas/library.h"
 #include "atlas/util/Config.h"
 
-namespace atlas {
-namespace grid {
-namespace detail {
-namespace grid {
+
+namespace atlas::grid::detail::grid {
 
 
 static class OrcaGridBuilder : public GridBuilder {
@@ -75,7 +73,4 @@ public:
 
 } orca_;
 
-}  // namespace grid
-}  // namespace detail
-}  // namespace grid
-}  // namespace atlas
+}  // namespace atlas::grid::detail::grid

--- a/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
+++ b/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
@@ -10,10 +10,10 @@
 
 #include "OrcaMeshGenerator.h"
 
-#include <unordered_set>
 #include <algorithm>
 #include <numeric>
 #include <tuple>
+#include <unordered_set>
 #include <utility>
 
 #include "eckit/utils/Hash.h"
@@ -75,7 +75,7 @@ struct SurroundingRectangle {
 
     SurroundingRectangle( const Grid& grid, const grid::Distribution& distribution, const Configuration& cfg ) {
         ATLAS_TRACE();
-        OrcaGrid orca{grid};
+        OrcaGrid orca{ grid };
         int mypart     = cfg.mypart;
         int nx_glb     = orca.nx();
         int ny_glb     = orca.ny();
@@ -105,10 +105,10 @@ struct SurroundingRectangle {
         {
             ATLAS_TRACE( "bounds" );
             atlas_omp_parallel {
-                int ix_min_TP = ix_min;
-                int ix_max_TP = ix_max;
-                int iy_min_TP = iy_min;
-                int iy_max_TP = iy_max;
+                int ix_min_TP         = ix_min;
+                int ix_max_TP         = ix_max;
+                int iy_min_TP         = iy_min;
+                int iy_max_TP         = iy_max;
                 int nb_nodes_owned_TP = 0;
                 atlas_omp_for( idx_t iy = iy_glb_min; iy <= iy_glb_max; iy++ ) {
                     for ( idx_t ix = ix_glb_min; ix <= ix_glb_max; ix++ ) {
@@ -124,10 +124,10 @@ struct SurroundingRectangle {
                 }
                 atlas_omp_critical {
                     nb_nodes_owned += nb_nodes_owned_TP;
-                    ix_min = std::min<int>( ix_min_TP, ix_min);
-                    ix_max = std::max<int>( ix_max_TP, ix_max);
-                    iy_min = std::min<int>( iy_min_TP, iy_min);
-                    iy_max = std::max<int>( iy_max_TP, iy_max);
+                    ix_min = std::min<int>( ix_min_TP, ix_min );
+                    ix_max = std::max<int>( ix_max_TP, ix_max );
+                    iy_min = std::min<int>( iy_min_TP, iy_min );
+                    iy_max = std::max<int>( iy_max_TP, iy_max );
                 }
             }
         }
@@ -209,20 +209,20 @@ struct Nodes {
     util::detail::BitflagsView<int> flags( idx_t i ) { return util::Topology::view( node_flags( i ) ); }
 
     Nodes( Mesh& mesh ) :
-        ij{array::make_view<idx_t, 2>( mesh.nodes().add(
-            Field( "ij", array::make_datatype<idx_t>(), array::make_shape( mesh.nodes().size(), 2 ) ) ) )},
-        xy{array::make_view<double, 2>( mesh.nodes().xy() )},
-        lonlat{array::make_view<double, 2>( mesh.nodes().lonlat() )},
-        glb_idx{array::make_view<gidx_t, 1>( mesh.nodes().global_index() )},
-        remote_idx{array::make_indexview<idx_t, 1>( mesh.nodes().remote_index() )},
-        part{array::make_view<int, 1>( mesh.nodes().partition() )},
-        ghost{array::make_view<int, 1>( mesh.nodes().ghost() )},
-        halo{array::make_view<int, 1>( mesh.nodes().halo() )},
-        node_flags{array::make_view<int, 1>( mesh.nodes().flags() )},
-        water{array::make_view<int, 1>( mesh.nodes().add(
-            Field( "water", array::make_datatype<int>(), array::make_shape( mesh.nodes().size() ) ) ) )},
-        master_glb_idx{array::make_view<gidx_t, 1>( mesh.nodes().add( Field(
-            "master_global_index", array::make_datatype<gidx_t>(), array::make_shape( mesh.nodes().size() ) ) ) )} {}
+        ij{ array::make_view<idx_t, 2>( mesh.nodes().add(
+            Field( "ij", array::make_datatype<idx_t>(), array::make_shape( mesh.nodes().size(), 2 ) ) ) ) },
+        xy{ array::make_view<double, 2>( mesh.nodes().xy() ) },
+        lonlat{ array::make_view<double, 2>( mesh.nodes().lonlat() ) },
+        glb_idx{ array::make_view<gidx_t, 1>( mesh.nodes().global_index() ) },
+        remote_idx{ array::make_indexview<idx_t, 1>( mesh.nodes().remote_index() ) },
+        part{ array::make_view<int, 1>( mesh.nodes().partition() ) },
+        ghost{ array::make_view<int, 1>( mesh.nodes().ghost() ) },
+        halo{ array::make_view<int, 1>( mesh.nodes().halo() ) },
+        node_flags{ array::make_view<int, 1>( mesh.nodes().flags() ) },
+        water{ array::make_view<int, 1>( mesh.nodes().add(
+            Field( "water", array::make_datatype<int>(), array::make_shape( mesh.nodes().size() ) ) ) ) },
+        master_glb_idx{ array::make_view<gidx_t, 1>( mesh.nodes().add( Field(
+            "master_global_index", array::make_datatype<gidx_t>(), array::make_shape( mesh.nodes().size() ) ) ) ) } {}
 };
 
 struct Cells {
@@ -233,10 +233,10 @@ struct Cells {
     mesh::HybridElements::Connectivity& node_connectivity;
     util::detail::BitflagsView<int> flags( idx_t i ) { return util::Topology::view( flags_view( i ) ); }
     Cells( Mesh& mesh ) :
-        part{array::make_view<int, 1>( mesh.cells().partition() )},
-        halo{array::make_view<int, 1>( mesh.cells().halo() )},
-        glb_idx{array::make_view<gidx_t, 1>( mesh.cells().global_index() )},
-        flags_view{array::make_view<int, 1>( mesh.cells().flags() )},
+        part{ array::make_view<int, 1>( mesh.cells().partition() ) },
+        halo{ array::make_view<int, 1>( mesh.cells().halo() ) },
+        glb_idx{ array::make_view<gidx_t, 1>( mesh.cells().global_index() ) },
+        flags_view{ array::make_view<int, 1>( mesh.cells().flags() ) },
         node_connectivity( mesh.cells().node_connectivity() ) {}
 };
 
@@ -245,11 +245,12 @@ StructuredGrid equivalent_regular_grid( const OrcaGrid& orca ) {
     ATLAS_ASSERT( orca );
 
     // Mimic hole in South pole, and numbering from South to North. patch determines if endpoint is at North Pole
-    StructuredGrid::YSpace yspace{grid::LinearSpacing{{-80., 90.}, orca.ny(), true}};  //not patch.at( orca.name() )}};
+    StructuredGrid::YSpace yspace{
+        grid::LinearSpacing{ { -80., 90. }, orca.ny(), true } };  //not patch.at( orca.name() )}};
     // Periodic xspace
-    StructuredGrid::XSpace xspace{grid::LinearSpacing{{0., 360.}, orca.nx(), false}};
+    StructuredGrid::XSpace xspace{ grid::LinearSpacing{ { 0., 360. }, orca.nx(), false } };
 
-    return StructuredGrid{xspace, yspace};
+    return StructuredGrid{ xspace, yspace };
 }
 }  // namespace
 
@@ -257,7 +258,7 @@ void OrcaMeshGenerator::generate( const Grid& grid, const grid::Distribution& di
     ATLAS_TRACE( "OrcaMeshGenerator::generate" );
     using Topology = util::Topology;
 
-    OrcaGrid orca{grid};
+    OrcaGrid orca{ grid };
     ATLAS_ASSERT( orca );
     ATLAS_ASSERT( !mesh.generated() );
 
@@ -270,7 +271,7 @@ void OrcaMeshGenerator::generate( const Grid& grid, const grid::Distribution& di
     // clone some grid properties
     setGrid( mesh, grid, distribution );
 
-    OrcaGrid rg{grid};
+    OrcaGrid rg{ grid };
 
     int nparts     = nparts_;
     int nx         = rg.nx();
@@ -294,7 +295,7 @@ void OrcaMeshGenerator::generate( const Grid& grid, const grid::Distribution& di
         return glbarray_offset + j * glbarray_jstride + i;
     };
 
-    const bool serial_distribution = (nparts == 1 || distribution.type() == "serial");
+    const bool serial_distribution = ( nparts == 1 || distribution.type() == "serial" );
 
     auto partition = [&]( idx_t i, idx_t j ) -> int {
         if ( nparts == 1 ) {
@@ -328,7 +329,7 @@ void OrcaMeshGenerator::generate( const Grid& grid, const grid::Distribution& di
     mesh.cells().add( new mesh::temporary::Quadrilateral(), ncells );
 #else
     // Use this since atlas 0.35.0
-    mesh.cells().add( mesh::ElementType::create("Quadrilateral"), ncells );
+    mesh.cells().add( mesh::ElementType::create( "Quadrilateral" ), ncells );
 #endif
 
     Cells cells( mesh );
@@ -385,12 +386,12 @@ void OrcaMeshGenerator::generate( const Grid& grid, const grid::Distribution& di
                 west = lon00 - 20.;
             }
 
-            auto normalise_lon_first_half  = util::NormaliseLongitude{west};
-            auto normalise_lon_second_half = util::NormaliseLongitude{lon00 + 90.};
+            auto normalise_lon_first_half  = util::NormaliseLongitude{ west };
+            auto normalise_lon_second_half = util::NormaliseLongitude{ lon00 + 90. };
             for ( idx_t ix = 0; ix < SR.nx; ix++ ) {
-                idx_t ix_glb   = SR.ix_min + ix;
+                idx_t ix_glb        = SR.ix_min + ix;
                 idx_t ix_glb_master = ix_glb;
-                auto normalise = [&]( double _xy[2] ) {
+                auto normalise      = [&]( double _xy[2] ) {
                     if ( ix_glb_master < nx / 2 ) {
                         _xy[LON] = normalise_lon_first_half( _xy[LON] );
                     }
@@ -448,7 +449,7 @@ void OrcaMeshGenerator::generate( const Grid& grid, const grid::Distribution& di
                         flags.set( Topology::GHOST );
                         nodes.remote_idx( inode ) = serial_distribution ? master_idx : -1;
 
-                        if( nodes.glb_idx(inode) != nodes.master_glb_idx(inode) ) {
+                        if ( nodes.glb_idx( inode ) != nodes.master_glb_idx( inode ) ) {
                             if ( ix_glb >= nx - orca.haloWest() ) {
                                 flags.set( Topology::PERIODIC );
                             }
@@ -457,7 +458,7 @@ void OrcaMeshGenerator::generate( const Grid& grid, const grid::Distribution& di
                             }
                             if ( iy_glb >= ny - orca.haloNorth() - 1 ) {
                                 flags.set( Topology::PERIODIC );
-                                if( _xy[LON] > lon00 + 90. ) {
+                                if ( _xy[LON] > lon00 + 90. ) {
                                     flags.set( Topology::EAST );
                                 }
                                 else {
@@ -465,22 +466,20 @@ void OrcaMeshGenerator::generate( const Grid& grid, const grid::Distribution& di
                                 }
                             }
 
-                            if( flags.check( Topology::PERIODIC ) ) {
+                            if ( flags.check( Topology::PERIODIC ) ) {
                                 // It can still happen that nodes were flagged as periodic wrongly
                                 // e.g. where the grid folds into itself
 
                                 idx_t iy_glb_master;
                                 double xy_master[2];
                                 orca.index2ij( master_idx, ix_glb_master, iy_glb_master );
-                                orca.lonlat(ix_glb_master,iy_glb_master,xy_master);
+                                orca.lonlat( ix_glb_master, iy_glb_master, xy_master );
                                 normalise( xy_master );
-                                if( std::abs(xy_master[LON] - _xy[LON]) < 1.e-12 ) {
-                                    flags.unset(Topology::PERIODIC);
+                                if ( std::abs( xy_master[LON] - _xy[LON] ) < 1.e-12 ) {
+                                    flags.unset( Topology::PERIODIC );
                                 }
                             }
-
                         }
-
                     }
 
                     flags.set( orca.land( ix_glb, iy_glb ) ? Topology::LAND : Topology::WATER );
@@ -493,7 +492,7 @@ void OrcaMeshGenerator::generate( const Grid& grid, const grid::Distribution& di
                     }
 
                     nodes.water( inode ) = orca.water( ix_glb, iy_glb );
-                    nodes.halo( inode ) = [&]() -> int {
+                    nodes.halo( inode )  = [&]() -> int {
                         if ( ix_glb < 0 ) {
                             return -ix_glb;
                         }
@@ -612,50 +611,51 @@ void OrcaMeshGenerator::generate( const Grid& grid, const grid::Distribution& di
             }
         }
     }
-    ATLAS_DEBUG_VAR(serial_distribution);
+    ATLAS_DEBUG_VAR( serial_distribution );
     if ( serial_distribution ) {
         // Bypass for "BuildParallelFields"
         mesh.nodes().metadata().set( "parallel", true );
 
         // Bypass for "BuildPeriodicBoundaries"
         mesh.metadata().set( "periodic", true );
-    } else {
-        ATLAS_DEBUG("build_remote_index");
-        build_remote_index(mesh);
+    }
+    else {
+        ATLAS_DEBUG( "build_remote_index" );
+        build_remote_index( mesh );
     }
 
     // Degenerate points in the ORCA mesh mean that the standard BuildHalo
     // methods for updating halo sizes will not work.
-    mesh.metadata().set("halo_locked", true);
+    mesh.metadata().set( "halo_locked", true );
     mesh.nodes().metadata().set<size_t>( "NbRealPts", nnodes );
     mesh.nodes().metadata().set<size_t>( "NbVirtualPts", size_t( 0 ) );
 }
 
 using Unique2Node = std::map<gidx_t, idx_t>;
-void OrcaMeshGenerator::build_remote_index(Mesh& mesh) {
+void OrcaMeshGenerator::build_remote_index( Mesh& mesh ) {
     ATLAS_TRACE();
 
     mesh::Nodes& nodes = mesh.nodes();
 
     bool parallel = false;
     bool periodic = false;
-    nodes.metadata().get("parallel", parallel);
-    mesh.metadata().get("periodic", periodic);
-    if (parallel | periodic) {
-        ATLAS_DEBUG("build_remote_index: already parallel, return");
+    nodes.metadata().get( "parallel", parallel );
+    mesh.metadata().get( "periodic", periodic );
+    if ( parallel | periodic ) {
+        ATLAS_DEBUG( "build_remote_index: already parallel, return" );
         return;
     }
 
     auto mpi_size = mpi::size();
     auto mypart   = mpi::rank();
-    int nb_nodes = nodes.size();
+    int nb_nodes  = nodes.size();
 
     // get the indices and partition data
-    auto master_glb_idx = array::make_view<gidx_t, 1>(nodes.field("master_global_index"));
+    auto master_glb_idx = array::make_view<gidx_t, 1>( nodes.field( "master_global_index" ) );
     auto glb_idx        = array::make_view<gidx_t, 1>( nodes.global_index() );
-    auto ridx    = array::make_indexview<idx_t, 1>( nodes.remote_index() );
-    auto part    = array::make_view<int, 1>( nodes.partition() );
-    auto ghost   = array::make_view<int, 1>( nodes.ghost() );
+    auto ridx           = array::make_indexview<idx_t, 1>( nodes.remote_index() );
+    auto part           = array::make_view<int, 1>( nodes.partition() );
+    auto ghost          = array::make_view<int, 1>( nodes.ghost() );
 
     // find the nodes I want to request the data for
     std::vector<std::vector<gidx_t>> send_uid( mpi_size );
@@ -663,21 +663,20 @@ void OrcaMeshGenerator::build_remote_index(Mesh& mesh) {
 
     Unique2Node global2local;
     for ( idx_t jnode = 0; jnode < nodes.size(); ++jnode ) {
-        gidx_t uid     = master_glb_idx(jnode);
-        if ( (part (jnode) != mypart)
-             || ((master_glb_idx( jnode ) != glb_idx( jnode )) &&
-                 (part( jnode ) == mypart))
-           ) {
-            send_uid[part(jnode)].push_back(uid);
-            req_lidx[part(jnode)].push_back(jnode);
-            ridx(jnode) = -1;
-        } else {
-            ridx(jnode) = jnode;
+        gidx_t uid = master_glb_idx( jnode );
+        if ( ( part( jnode ) != mypart ) ||
+             ( ( master_glb_idx( jnode ) != glb_idx( jnode ) ) && ( part( jnode ) == mypart ) ) ) {
+            send_uid[part( jnode )].push_back( uid );
+            req_lidx[part( jnode )].push_back( jnode );
+            ridx( jnode ) = -1;
         }
-        if (not ghost(jnode)) {
-            bool inserted = global2local.insert(std::make_pair(uid, jnode)).second;
-            ATLAS_ASSERT(inserted, std::string("index already inserted ") + std::to_string(uid) + ", "
-                + std::to_string(jnode) + " at jnode " + std::to_string(global2local[uid]));
+        else {
+            ridx( jnode ) = jnode;
+        }
+        if ( not ghost( jnode ) ) {
+            bool inserted = global2local.insert( std::make_pair( uid, jnode ) ).second;
+            ATLAS_ASSERT( inserted, std::string( "index already inserted " ) + std::to_string( uid ) + ", " +
+                                        std::to_string( jnode ) + " at jnode " + std::to_string( global2local[uid] ) );
         }
     }
 
@@ -690,20 +689,19 @@ void OrcaMeshGenerator::build_remote_index(Mesh& mesh) {
     std::vector<std::vector<int>> send_ridx( mpi_size );
     std::vector<std::vector<int>> send_gidx( mpi_size );
     std::vector<std::vector<int>> send_part( mpi_size );
-    for ( idx_t p = 0; p < mpi_size; ++p) {
-      for ( idx_t i = 0; i < recv_uid[p].size(); ++i ) {
-          idx_t found_idx = -1;
-          gidx_t uid     = recv_uid[p][i];
-          Unique2Node::const_iterator found = global2local.find(uid);
-          if (found != global2local.end()) {
-              found_idx = found->second;
-          }
-          ATLAS_ASSERT(found_idx != -1,
-              "master global index not found: " + std::to_string(recv_uid[p][i]));
-          send_ridx[p].push_back(ridx(found_idx));
-          send_gidx[p].push_back(glb_idx(found_idx));
-          send_part[p].push_back(part(found_idx));
-      }
+    for ( idx_t p = 0; p < mpi_size; ++p ) {
+        for ( idx_t i = 0; i < recv_uid[p].size(); ++i ) {
+            idx_t found_idx                   = -1;
+            gidx_t uid                        = recv_uid[p][i];
+            Unique2Node::const_iterator found = global2local.find( uid );
+            if ( found != global2local.end() ) {
+                found_idx = found->second;
+            }
+            ATLAS_ASSERT( found_idx != -1, "master global index not found: " + std::to_string( recv_uid[p][i] ) );
+            send_ridx[p].push_back( ridx( found_idx ) );
+            send_gidx[p].push_back( glb_idx( found_idx ) );
+            send_part[p].push_back( part( found_idx ) );
+        }
     }
 
     std::vector<std::vector<int>> recv_ridx( mpi_size );
@@ -715,19 +713,18 @@ void OrcaMeshGenerator::build_remote_index(Mesh& mesh) {
     mpi::comm().allToAll( send_part, recv_part );
 
     // Fill out missing remote indices
-    for ( idx_t p = 0; p < mpi_size; ++p) {
-      for ( idx_t i = 0; i < recv_ridx[p].size(); ++i ) {
-        ridx(req_lidx[p][i]) = recv_ridx[p][i];
-        glb_idx(req_lidx[p][i]) = recv_gidx[p][i];
-        part(req_lidx[p][i]) = recv_part[p][i];
-      }
+    for ( idx_t p = 0; p < mpi_size; ++p ) {
+        for ( idx_t i = 0; i < recv_ridx[p].size(); ++i ) {
+            ridx( req_lidx[p][i] )    = recv_ridx[p][i];
+            glb_idx( req_lidx[p][i] ) = recv_gidx[p][i];
+            part( req_lidx[p][i] )    = recv_part[p][i];
+        }
     }
 
     // sanity check
-    for (idx_t jnode = 0; jnode < nb_nodes; ++jnode)
-        ATLAS_ASSERT(ridx(jnode) >= 0,
-            "ridx not filled with part " + std::to_string(part(jnode)) + " at "
-            + std::to_string(jnode));
+    for ( idx_t jnode = 0; jnode < nb_nodes; ++jnode )
+        ATLAS_ASSERT( ridx( jnode ) >= 0, "ridx not filled with part " + std::to_string( part( jnode ) ) + " at " +
+                                              std::to_string( jnode ) );
 
     mesh.metadata().set( "periodic", true );
     nodes.metadata().set( "parallel", true );
@@ -737,15 +734,15 @@ OrcaMeshGenerator::OrcaMeshGenerator( const eckit::Parametrisation& config ) {
     config.get( "partition", mypart_ = mpi::rank() );
     config.get( "partitions", nparts_ = mpi::size() );
     config.get( "halo", halo_ = 0 );
-    if (halo_ != 0)
-      throw_NotImplemented("Only 0 halo ORCA grids are currently supported", Here());
+    if ( halo_ != 0 )
+        throw_NotImplemented( "Only 0 halo ORCA grids are currently supported", Here() );
 }
 
 void OrcaMeshGenerator::generate( const Grid& grid, const grid::Partitioner& partitioner, Mesh& mesh ) const {
-    std::unordered_set<std::string> valid_distributions = {"serial", "checkerboard", "equal_regions", "equal_area"};
-    ATLAS_ASSERT(valid_distributions.find(partitioner.type()) != valid_distributions.end(),
-                 partitioner.type() + " is not an implemented distribution type. "
-                 + "Valid types are 'serial', 'checkerboard' or 'equal_regions', 'equal_area'");
+    std::unordered_set<std::string> valid_distributions = { "serial", "checkerboard", "equal_regions", "equal_area" };
+    ATLAS_ASSERT( valid_distributions.find( partitioner.type() ) != valid_distributions.end(),
+                  partitioner.type() + " is not an implemented distribution type. " +
+                      "Valid types are 'serial', 'checkerboard' or 'equal_regions', 'equal_area'" );
     auto regular_grid = equivalent_regular_grid( grid );
     auto distribution = grid::Distribution( regular_grid, partitioner );
     generate( grid, distribution, mesh );

--- a/src/atlas-orca/meshgenerator/OrcaMeshGenerator.h
+++ b/src/atlas-orca/meshgenerator/OrcaMeshGenerator.h
@@ -24,22 +24,21 @@ class Mesh;
 class OrcaGrid;
 }  // namespace atlas
 
-namespace atlas {
-namespace grid {
+
+namespace atlas::grid {
 class Distribution;
-}  // namespace grid
-}  // namespace atlas
+}  // namespace atlas::grid
+
 #endif
 
-namespace atlas {
-namespace orca {
-namespace meshgenerator {
+
+namespace atlas::orca::meshgenerator {
 
 //----------------------------------------------------------------------------------------------------------------------
 
 class OrcaMeshGenerator : public MeshGenerator::Implementation {
 public:
-    OrcaMeshGenerator( const eckit::Parametrisation& = util::NoConfig() );
+    explicit OrcaMeshGenerator( const eckit::Parametrisation& = util::NoConfig() );
 
     using MeshGenerator::Implementation::generate;
 
@@ -63,6 +62,4 @@ private:
 
 //----------------------------------------------------------------------------------------------------------------------
 
-}  // namespace meshgenerator
-}  // namespace orca
-}  // namespace atlas
+}  // namespace atlas::orca::meshgenerator

--- a/src/atlas-orca/meshgenerator/OrcaMeshGenerator.h
+++ b/src/atlas-orca/meshgenerator/OrcaMeshGenerator.h
@@ -52,10 +52,10 @@ public:
 
 private:
     void hash( eckit::Hash& ) const override;
-    static void build_remote_index(Mesh& mesh);
+    static void build_remote_index( Mesh& mesh );
 
-    bool include_pole_{false};
-    bool fixup_{true};
+    bool include_pole_{ false };
+    bool fixup_{ true };
     int nparts_;
     int mypart_;
     int halo_;

--- a/src/atlas-orca/util/AtlasIOReader.h
+++ b/src/atlas-orca/util/AtlasIOReader.h
@@ -10,17 +10,11 @@
 
 #pragma once
 
-#include <cstring>
-#include <fstream>
-#include <iostream>
 #include <sstream>
 #include <string>
 
+#include "eckit/codec/codec.h"
 
-#include "eckit/filesystem/PathName.h"
-#include "eckit/log/ProgressTimer.h"
-
-#include "atlas/io/atlas-io.h"
 #include "atlas/runtime/Exception.h"
 
 #include "atlas-orca/util/OrcaData.h"
@@ -31,14 +25,14 @@ namespace orca {
 
 class AtlasIOReader {
 public:
-    AtlasIOReader( const util::Config& config = util::NoConfig() ) {}
+    explicit AtlasIOReader( const util::Config& = util::NoConfig() ) {}
 
     void read( const std::string& uri, OrcaData& data ) {
         OrcaDataFile file{uri};
 
-        io::RecordReader reader( file );
+        eckit::codec::RecordReader reader( file );
 
-        int version;
+        int version = 0;
         reader.read( "version", version ).wait();
         if ( version == 0 ) {
             reader.read( "dimensions", data.dimensions );

--- a/src/atlas-orca/util/AtlasIOReader.h
+++ b/src/atlas-orca/util/AtlasIOReader.h
@@ -28,7 +28,7 @@ public:
     explicit AtlasIOReader( const util::Config& = util::NoConfig() ) {}
 
     void read( const std::string& uri, OrcaData& data ) {
-        OrcaDataFile file{uri};
+        OrcaDataFile file{ uri };
 
         eckit::codec::RecordReader reader( file );
 

--- a/src/atlas-orca/util/AtlasIOReader.h
+++ b/src/atlas-orca/util/AtlasIOReader.h
@@ -20,8 +20,8 @@
 #include "atlas-orca/util/OrcaData.h"
 #include "atlas-orca/util/OrcaDataFile.h"
 
-namespace atlas {
-namespace orca {
+
+namespace atlas::orca {
 
 class AtlasIOReader {
 public:
@@ -49,7 +49,7 @@ public:
     }
 };
 
-}  // namespace orca
-}  // namespace atlas
+}  // namespace atlas::orca
+
 
 //------------------------------------------------------------------------------------------------------

--- a/src/atlas-orca/util/AtlasIOReader.h
+++ b/src/atlas-orca/util/AtlasIOReader.h
@@ -13,8 +13,15 @@
 #include <sstream>
 #include <string>
 
+#if ATLAS_ORCA_HAVE_ECKIT_CODEC
 #include "eckit/codec/codec.h"
-
+#else
+// Backward compatibility, DEPRECATED!
+#include "atlas/io/atlas-io.h"
+namespace eckit::codec {
+using RecordReader = atlas::io::RecordReader;
+}
+#endif
 #include "atlas/runtime/Exception.h"
 
 #include "atlas-orca/util/OrcaData.h"

--- a/src/atlas-orca/util/ComputeCachedPath.h
+++ b/src/atlas-orca/util/ComputeCachedPath.h
@@ -27,18 +27,16 @@ namespace orca {
 class FileSearch {
 public:
     FileSearch( const std::vector<std::string> search_paths, const std::vector<std::string>& known_urls ) :
-        search_paths_{search_paths},
-        known_urls_{known_urls} {
-    }
+        search_paths_{ search_paths }, known_urls_{ known_urls } {}
     bool operator()( const std::string& url, eckit::PathName& path ) const {
-        std::string search_file = file(url);
-        for( auto& search_path : search_paths_ ) {
+        std::string search_file = file( url );
+        for ( auto& search_path : search_paths_ ) {
             std::string join = "";
-            if( not search_path.empty() && search_path[search_path.size()-1] != '/' ) {
+            if ( not search_path.empty() && search_path[search_path.size() - 1] != '/' ) {
                 join = "/";
             }
             eckit::PathName search = search_path + join + search_file;
-            if( search.exists() ) {
+            if ( search.exists() ) {
                 path = search;
                 return true;
             }
@@ -60,7 +58,7 @@ public:
                 std::string filename = url.substr( url.find_last_of( "/" ), url.size() );
                 return "atlas/grids/orca/unknown" + filename;
             }
-            ATLAS_THROW_EXCEPTION("Should not be here");
+            ATLAS_THROW_EXCEPTION( "Should not be here" );
         }
         else {
             return url;
@@ -69,8 +67,8 @@ public:
 
     std::string searchPath() const {
         std::stringstream joined;
-        for( size_t i=0; i<search_paths_.size(); ++i ) {
-            if( i > 0 ) {
+        for ( size_t i = 0; i < search_paths_.size(); ++i ) {
+            if ( i > 0 ) {
                 joined << ":";
             }
             joined << search_paths_[i];
@@ -85,7 +83,7 @@ private:
 
 class ComputeCachedPath {
 public:
-    ComputeCachedPath( const std::vector<std::string>& known_urls ) : known_urls_{known_urls} {}
+    ComputeCachedPath( const std::vector<std::string>& known_urls ) : known_urls_{ known_urls } {}
     eckit::PathName operator()( const std::string& url ) const {
         eckit::PathName path;
         bool is_known_url = false;

--- a/src/atlas-orca/util/ComputeUid.cc
+++ b/src/atlas-orca/util/ComputeUid.cc
@@ -22,8 +22,8 @@
 
 #include "atlas-orca/util/Enums.h"
 
-namespace atlas {
-namespace orca {
+
+namespace atlas::orca {
 
 std::string compute_uid( const std::string& arrangement, const double lon[], const double lat[], size_t size ) {
     ATLAS_TRACE();
@@ -36,9 +36,11 @@ std::string compute_uid( const std::string& arrangement, const double lon[], con
     eckit::MD5 hasher;
     hasher.add( P );
 
+    auto len = static_cast<long>( size * sizeof( double ) );
+
     if ( eckit_LITTLE_ENDIAN ) {
-        hasher.add( lat, size * sizeof( double ) );
-        hasher.add( lon, size * sizeof( double ) );
+        hasher.add( lat, len );
+        hasher.add( lon, len );
     }
     else {
         atlas::vector<double> latitude( size );
@@ -49,11 +51,10 @@ std::string compute_uid( const std::string& arrangement, const double lon[], con
         }
         eckit::byteswap( latitude.data(), size );
         eckit::byteswap( longitude.data(), size );
-        hasher.add( latitude.data(), size * sizeof( double ) );
-        hasher.add( longitude.data(), size * sizeof( double ) );
+        hasher.add( latitude.data(), len );
+        hasher.add( longitude.data(), len );
     }
     return hasher.digest();
 }
 
-}  // namespace orca
-}  // namespace atlas
+}  // namespace atlas::orca

--- a/src/atlas-orca/util/ComputeUid.h
+++ b/src/atlas-orca/util/ComputeUid.h
@@ -15,8 +15,8 @@
 #include <string>
 #include <vector>
 
-namespace atlas {
-namespace orca {
+
+namespace atlas::orca {
 
 //------------------------------------------------------------------------------------------------------
 
@@ -24,5 +24,4 @@ std::string compute_uid( const std::string& arrangement, const double lon[], con
 
 //------------------------------------------------------------------------------------------------------
 
-}  // namespace orca
-}  // namespace atlas
+}  // namespace atlas::orca

--- a/src/atlas-orca/util/DetectInvalidElements.cc
+++ b/src/atlas-orca/util/DetectInvalidElements.cc
@@ -19,7 +19,7 @@ namespace atlas {
 namespace orca {
 
 bool DetectInvalidElement::invalid_quad_2d( const PointLonLat& p_SW, const PointLonLat& p_SE, const PointLonLat& p_NE,
-                        const PointLonLat& p_NW ) const {
+                                            const PointLonLat& p_NW ) const {
     double dlat_W = p_NW.lat() - p_SW.lat();
     double dlat_E = p_NE.lat() - p_SE.lat();
     double dlon_N = p_NE.lon() - p_NW.lon();
@@ -28,16 +28,17 @@ bool DetectInvalidElement::invalid_quad_2d( const PointLonLat& p_SW, const Point
 }
 
 bool DetectInvalidElement::invalid_quad_3d( const PointLonLat& p_SW, const PointLonLat& p_SE, const PointLonLat& p_NE,
-                        const PointLonLat& p_NW ) const {
-    PointXYZ xyz_SW{sphere_.xyz( p_SW )};
-    PointXYZ xyz_SE{sphere_.xyz( p_SE )};
-    PointXYZ xyz_NE{sphere_.xyz( p_NE )};
-    PointXYZ xyz_NW{sphere_.xyz( p_NW )};
-    return not atlas::interpolation::element::Quad3D{xyz_SW, xyz_SE, xyz_NE, xyz_NW}.validate();
+                                            const PointLonLat& p_NW ) const {
+    PointXYZ xyz_SW{ sphere_.xyz( p_SW ) };
+    PointXYZ xyz_SE{ sphere_.xyz( p_SE ) };
+    PointXYZ xyz_NE{ sphere_.xyz( p_NE ) };
+    PointXYZ xyz_NW{ sphere_.xyz( p_NW ) };
+    return not atlas::interpolation::element::Quad3D{ xyz_SW, xyz_SE, xyz_NE, xyz_NW }.validate();
 }
 
-bool DetectInvalidElement::diagonal_too_large( const PointLonLat& p_SW, const PointLonLat& p_SE, const PointLonLat& p_NE,
-                            const PointLonLat& p_NW, double largest_diagonal ) const {
+bool DetectInvalidElement::diagonal_too_large( const PointLonLat& p_SW, const PointLonLat& p_SE,
+                                               const PointLonLat& p_NE, const PointLonLat& p_NW,
+                                               double largest_diagonal ) const {
     if ( largest_diagonal == 0. ) {
         return false;
     }
@@ -48,14 +49,14 @@ bool DetectInvalidElement::diagonal_too_large( const PointLonLat& p_SW, const Po
     return std::max( d2_NW_SE, d2_SW_NE ) > diagonal_treshold_2;
 }
 
-bool DetectInvalidElement::diagonal_too_large( const PointLonLat& p_SW, const PointLonLat& p_SE, const PointLonLat& p_NE,
-                            const PointLonLat& p_NW ) const {
+bool DetectInvalidElement::diagonal_too_large( const PointLonLat& p_SW, const PointLonLat& p_SE,
+                                               const PointLonLat& p_NE, const PointLonLat& p_NW ) const {
     return diagonal_too_large( p_SW, p_SE, p_NE, p_NW, largest_diatonal_ );
 }
 
 bool DetectInvalidElement::invalid_element( const PointLonLat& p_SW, const PointLonLat& p_SE, const PointLonLat& p_NE,
-                        const PointLonLat& p_NW, Statistics& statistics ) const {
-    double lat_max = std::max( {p_SW.lat(), p_SE.lat(), p_NE.lat(), p_NW.lat()} );
+                                            const PointLonLat& p_NW, Statistics& statistics ) const {
+    double lat_max = std::max( { p_SW.lat(), p_SE.lat(), p_NE.lat(), p_NW.lat() } );
 
     if ( invalid_quad_2d( p_SW, p_SE, p_NE, p_NW ) && lat_max < 45. ) {
         statistics.invalid_quads_2d++;
@@ -74,8 +75,8 @@ bool DetectInvalidElement::invalid_element( const PointLonLat& p_SW, const Point
     }
     if ( orca2_ ) {
         if ( lat_max < 60. ) {
-            constexpr util::NormaliseLongitude normalized{-180.};
-            double lon_min = normalized( std::min( {p_SW.lon(), p_SE.lon(), p_NE.lon(), p_NW.lon()} ) );
+            constexpr util::NormaliseLongitude normalized{ -180. };
+            double lon_min = normalized( std::min( { p_SW.lon(), p_SE.lon(), p_NE.lon(), p_NW.lon() } ) );
             if ( lon_min > -20. && lon_min < 20. ) {
                 double dlat_W = p_NW.lat() - p_SW.lat();
                 double dlat_E = p_NE.lat() - p_SE.lat();
@@ -92,7 +93,7 @@ bool DetectInvalidElement::invalid_element( const PointLonLat& p_SW, const Point
 }
 
 bool DetectInvalidElement::invalid_element( const PointLonLat& p_SW, const PointLonLat& p_SE, const PointLonLat& p_NE,
-                        const PointLonLat& p_NW ) const {
+                                            const PointLonLat& p_NW ) const {
     Statistics statistics;
     return invalid_element( p_SW, p_SE, p_NE, p_NW, statistics );
 }

--- a/src/atlas-orca/util/DetectInvalidElements.cc
+++ b/src/atlas-orca/util/DetectInvalidElements.cc
@@ -15,8 +15,8 @@
 #include "atlas/interpolation/element/Quad3D.h"
 #include "atlas/util/NormaliseLongitude.h"
 
-namespace atlas {
-namespace orca {
+
+namespace atlas::orca {
 
 bool DetectInvalidElement::invalid_quad_2d( const PointLonLat& p_SW, const PointLonLat& p_SE, const PointLonLat& p_NE,
                                             const PointLonLat& p_NW ) const {
@@ -78,8 +78,8 @@ bool DetectInvalidElement::invalid_element( const PointLonLat& p_SW, const Point
             constexpr util::NormaliseLongitude normalized{ -180. };
             double lon_min = normalized( std::min( { p_SW.lon(), p_SE.lon(), p_NE.lon(), p_NW.lon() } ) );
             if ( lon_min > -20. && lon_min < 20. ) {
-                double dlat_W = p_NW.lat() - p_SW.lat();
-                double dlat_E = p_NE.lat() - p_SE.lat();
+                // double dlat_W = p_NW.lat() - p_SW.lat();
+                // double dlat_E = p_NE.lat() - p_SE.lat();
                 double dlon_N = p_NE.lon() - p_NW.lon();
                 double dlon_S = p_SE.lon() - p_SW.lon();
                 if ( std::max( dlon_N, dlon_S ) > 2. * std::min( dlon_N, dlon_S ) ) {
@@ -99,5 +99,4 @@ bool DetectInvalidElement::invalid_element( const PointLonLat& p_SW, const Point
 }
 
 
-}  // namespace orca
-}  // namespace atlas
+}  // namespace atlas::orca

--- a/src/atlas-orca/util/DetectInvalidElements.h
+++ b/src/atlas-orca/util/DetectInvalidElements.h
@@ -20,10 +20,10 @@ namespace orca {
 class DetectInvalidElement {
 public:
     struct Statistics {
-        size_t invalid_elements{0};
-        size_t invalid_quads_3d{0};
-        size_t invalid_quads_2d{0};
-        size_t diagonal_too_large{0};
+        size_t invalid_elements{ 0 };
+        size_t invalid_quads_3d{ 0 };
+        size_t invalid_quads_2d{ 0 };
+        size_t diagonal_too_large{ 0 };
     };
 
     DetectInvalidElement( const util::Config& config ) {
@@ -51,8 +51,8 @@ public:
 
 private:
     geometry::Earth sphere_;
-    double largest_diatonal_{0};
-    bool orca2_{false};
+    double largest_diatonal_{ 0 };
+    bool orca2_{ false };
 };
 
 }  // namespace orca

--- a/src/atlas-orca/util/DetectInvalidElements.h
+++ b/src/atlas-orca/util/DetectInvalidElements.h
@@ -14,8 +14,8 @@
 #include "atlas/util/Geometry.h"
 #include "atlas/util/Point.h"
 
-namespace atlas {
-namespace orca {
+
+namespace atlas::orca {
 
 class DetectInvalidElement {
 public:
@@ -26,7 +26,7 @@ public:
         size_t diagonal_too_large{ 0 };
     };
 
-    DetectInvalidElement( const util::Config& config ) {
+    explicit DetectInvalidElement( const util::Config& config ) {
         config.get( "ORCA2", orca2_ );
         config.get( "diagonal", largest_diatonal_ );
     }
@@ -55,5 +55,4 @@ private:
     bool orca2_{ false };
 };
 
-}  // namespace orca
-}  // namespace atlas
+}  // namespace atlas::orca

--- a/src/atlas-orca/util/Download.cc
+++ b/src/atlas-orca/util/Download.cc
@@ -67,18 +67,16 @@ size_t download( const std::string& url, const eckit::PathName& path ) {
 #ifdef ATLAS_ORCA_HAVE_ECKIT_URLHANDLE
     try {
         length = eckit::URLHandle( url ).saveInto( path_tmp );
-        if( length <= 0 && eckit_version_int() <= 11601 /*1.16.1*/ ) {
+        if ( length <= 0 && eckit_version_int() <= 11601 /*1.16.1*/ ) {
             // Problems with eckit::URLHandle fixed in further version
-            Log::warning() << "Download failed with eckit::URLHandle. Trying again with curl system call."
-                           << std::endl;
+            Log::warning() << "Download failed with eckit::URLHandle. Trying again with curl system call." << std::endl;
             length = curl_download( url, path_tmp );
         }
     }
     catch ( eckit::SeriousBug ) {
-        Log::warning() << "Download failed with eckit::URLHandle. Trying again with curl system call."
-                       << std::endl;
+        Log::warning() << "Download failed with eckit::URLHandle. Trying again with curl system call." << std::endl;
 #else
-    try{
+    try {
 #endif
         length = curl_download( url, path_tmp );
     }
@@ -96,9 +94,9 @@ size_t download( const std::string& url, const eckit::PathName& path ) {
         std::string content;
         content.resize( path_tmp.size() );
 
-        eckit::FileHandle file(path_tmp);
+        eckit::FileHandle file( path_tmp );
         file.openForRead();
-        file.read(const_cast<char*>(content.data()), content.size());
+        file.read( const_cast<char*>( content.data() ), content.size() );
         file.close();
 
         if ( content.find( "Error 404" ) ) {

--- a/src/atlas-orca/util/Download.cc
+++ b/src/atlas-orca/util/Download.cc
@@ -29,11 +29,17 @@
 #endif
 
 
-namespace atlas {
-namespace orca {
+namespace atlas::orca {
 
 struct AutoIndent {
     AutoIndent() { Log::info().indent(); }
+
+    AutoIndent( const AutoIndent& ) = delete;
+    AutoIndent( AutoIndent&& )      = delete;
+
+    void operator=( const AutoIndent& ) = delete;
+    void operator=( AutoIndent&& )      = delete;
+
     ~AutoIndent() {
         if ( Log::info() ) {
             Log::info().unindent();
@@ -96,20 +102,20 @@ size_t download( const std::string& url, const eckit::PathName& path ) {
 
         eckit::FileHandle file( path_tmp );
         file.openForRead();
-        file.read( const_cast<char*>( content.data() ), content.size() );
+        file.read( const_cast<char*>( content.data() ), static_cast<long>( content.size() ) );
         file.close();
 
-        if ( content.find( "Error 404" ) ) {
+        if ( content.find( "Error 404" ) != 0 ) {
             path_tmp.unlink( true );
             return 0;
         }
     }
     eckit::PathName::rename( path_tmp, path );
     trace.stop();
-    Log::info() << "Download of " << eckit::Bytes( length ) << " took " << trace.elapsed() << " s." << std::endl;
+    Log::info() << "Download of " << eckit::Bytes( static_cast<double>( length ) ) << " took " << trace.elapsed()
+                << " s." << std::endl;
     return length;
 };
 
 
-}  // namespace orca
-}  // namespace atlas
+}  // namespace atlas::orca

--- a/src/atlas-orca/util/Download.h
+++ b/src/atlas-orca/util/Download.h
@@ -14,11 +14,10 @@
 
 #include "eckit/filesystem/PathName.h"
 
-namespace atlas {
-namespace orca {
+
+namespace atlas::orca {
 
 size_t download( const std::string& url, const eckit::PathName& path );
 
 
-}  // namespace orca
-}  // namespace atlas
+}  // namespace atlas::orca

--- a/src/atlas-orca/util/Enums.h
+++ b/src/atlas-orca/util/Enums.h
@@ -10,8 +10,8 @@
 
 #pragma once
 
-namespace atlas {
-namespace orca {
+
+namespace atlas::orca {
 
 //------------------------------------------------------------------------------------------------------
 
@@ -22,5 +22,4 @@ static constexpr int HALO_EAST  = 3;
 
 //------------------------------------------------------------------------------------------------------
 
-}  // namespace orca
-}  // namespace atlas
+}  // namespace atlas::orca

--- a/src/atlas-orca/util/Flag.h
+++ b/src/atlas-orca/util/Flag.h
@@ -17,8 +17,8 @@
 #include "atlas/array/DataType.h"
 #include "atlas/runtime/Exception.h"
 
-namespace atlas {
-namespace orca {
+
+namespace atlas::orca {
 
 //------------------------------------------------------------------------------------------------------
 
@@ -28,8 +28,8 @@ public:
     static constexpr int WATER           = 1;
     static constexpr int INVALID_ELEMENT = 2;
 
-    Flag( std::byte& b ) : byte( b ) { std::memcpy( &bits, &byte, sizeof( std::byte ) ); }
-    Flag( const std::byte& b ) : byte( const_cast<std::byte&>( b ) ), read_only{ true } {
+    explicit Flag( std::byte& b ) : byte( b ) { std::memcpy( &bits, &byte, sizeof( std::byte ) ); }
+    explicit Flag( const std::byte& b ) : byte( const_cast<std::byte&>( b ) ), read_only{ true } {
         std::memcpy( &bits, &byte, sizeof( std::byte ) );
     }
     void set( int pos ) {
@@ -52,5 +52,4 @@ private:
 
 //------------------------------------------------------------------------------------------------------
 
-}  // namespace orca
-}  // namespace atlas
+}  // namespace atlas::orca

--- a/src/atlas-orca/util/Flag.h
+++ b/src/atlas-orca/util/Flag.h
@@ -29,7 +29,7 @@ public:
     static constexpr int INVALID_ELEMENT = 2;
 
     Flag( std::byte& b ) : byte( b ) { std::memcpy( &bits, &byte, sizeof( std::byte ) ); }
-    Flag( const std::byte& b ) : byte( const_cast<std::byte&>( b ) ), read_only{true} {
+    Flag( const std::byte& b ) : byte( const_cast<std::byte&>( b ) ), read_only{ true } {
         std::memcpy( &bits, &byte, sizeof( std::byte ) );
     }
     void set( int pos ) {
@@ -47,7 +47,7 @@ public:
 private:
     std::bitset<8> bits;  // 1 byte  ( WARNING, sizeof(std::bitset<8>) != 1; it is compiler dependent, usually 4 or 8 )
     std::byte& byte;
-    bool read_only{false};
+    bool read_only{ false };
 };
 
 //------------------------------------------------------------------------------------------------------

--- a/src/atlas-orca/util/OrcaData.cc
+++ b/src/atlas-orca/util/OrcaData.cc
@@ -10,7 +10,18 @@
 
 #include "OrcaData.h"
 
+#if ATLAS_ORCA_HAVE_ECKIT_CODEC
 #include "eckit/codec/codec.h"
+#else
+// Backward compatibility, DEPRECATED!
+#include "atlas/io/atlas-io.h"
+namespace eckit::codec {
+using RecordWriter = atlas::io::RecordWriter;
+using atlas::io::ref;
+using atlas::io::ArrayReference;
+}
+#endif
+
 #include "eckit/log/ProgressTimer.h"
 
 #include "atlas/runtime/Log.h"

--- a/src/atlas-orca/util/OrcaData.cc
+++ b/src/atlas-orca/util/OrcaData.cc
@@ -10,8 +10,8 @@
 
 #include "OrcaData.h"
 
-#include "eckit/log/ProgressTimer.h"
 #include "eckit/codec/codec.h"
+#include "eckit/log/ProgressTimer.h"
 
 #include "atlas/runtime/Log.h"
 #include "atlas/runtime/Trace.h"
@@ -29,11 +29,11 @@ void OrcaData::setGhost() {
     idx_t ni = dimensions[0];
     idx_t nj = dimensions[1];
 
-    OrcaPeriodicity compute_master{*this};
+    OrcaPeriodicity compute_master{ *this };
     for ( idx_t j = 0; j < nj; ++j ) {
         for ( idx_t i = 0; i < ni; ++i ) {
             idx_t n = ni * j + i;
-            Flag flag{flags[n]};
+            Flag flag{ flags[n] };
             flag.unset( Flag::GHOST );
             auto master = compute_master( i, j );
             if ( j < halo[HALO_SOUTH] ) {
@@ -49,7 +49,7 @@ void OrcaData::setGhost() {
 void OrcaData::makeHaloConsistent() {
     size_t ni = dimensions[0];
     size_t nj = dimensions[1];
-    OrcaPeriodicity compute_master{*this};
+    OrcaPeriodicity compute_master{ *this };
     for ( size_t j = 0; j < nj; ++j ) {
         for ( size_t i = 0; i < ni; ++i ) {
             size_t n        = ni * j + i;
@@ -57,8 +57,8 @@ void OrcaData::makeHaloConsistent() {
             size_t n_master = ni * master.j + master.i;
             if ( n_master != n ) {
                 if ( lon[n] != lon[n_master] || lat[n] != lat[n_master] ) {
-                    PointLonLat point_n{lon[n], lat[n]};
-                    PointLonLat point_n_master{lon[n_master], lat[n_master]};
+                    PointLonLat point_n{ lon[n], lat[n] };
+                    PointLonLat point_n_master{ lon[n_master], lat[n_master] };
                     double distance = geometry::Earth().distance( point_n, point_n_master );
                     if ( distance > 1 /*metre*/ ) {
                         Log::warning() << "Fixed halo inconsistency for {" << i << "," << j << "}:  " << point_n
@@ -69,8 +69,8 @@ void OrcaData::makeHaloConsistent() {
                 lon[n] = lon[n_master];
                 lat[n] = lat[n_master];
 
-                Flag flag_n{flags[n]};
-                Flag flag_n_master{flags[n_master]};
+                Flag flag_n{ flags[n] };
+                Flag flag_n_master{ flags[n_master] };
                 if ( flag_n.test( Flag::WATER ) != flag_n_master.test( Flag::WATER ) ) {
                     flag_n.unset( Flag::WATER );
                     if ( flag_n_master.test( Flag::WATER ) ) {
@@ -112,7 +112,7 @@ DetectInvalidElement::Statistics atlas::orca::OrcaData::detectInvalidElements( c
     detection_config.set( "diagonal", resolution * diagonal_factor );
     DetectInvalidElement detect( detection_config );
 
-    auto is_water = [&]( int n ) -> bool { return Flag{flags[n]}.test( Flag::WATER ); };
+    auto is_water = [&]( int n ) -> bool { return Flag{ flags[n] }.test( Flag::WATER ); };
 
     eckit::ProgressTimer progress( "Detect invalid elements", ( nj - 1 ) * ( ni - 1 ), "point", 5., Log::trace() );
     for ( idx_t j = 0; j < nj - 1; ++j ) {
@@ -123,14 +123,14 @@ DetectInvalidElement::Statistics atlas::orca::OrcaData::detectInvalidElements( c
             idx_t n_NW = ( j + 1 ) * ni + i;
             idx_t n_NE = n_NW + 1;
 
-            Flag{flags[n_SW]}.unset( Flag::INVALID_ELEMENT );
+            Flag{ flags[n_SW] }.unset( Flag::INVALID_ELEMENT );
 
             bool element_contains_water = is_water( n_SW ) || is_water( n_SE ) || is_water( n_NW ) || is_water( n_NE );
 
-            PointLonLat p_SW{lon[n_SW], lat[n_SW]};
-            PointLonLat p_SE{lon[n_SE], lat[n_SE]};
-            PointLonLat p_NW{lon[n_NW], lat[n_NW]};
-            PointLonLat p_NE{lon[n_NE], lat[n_NE]};
+            PointLonLat p_SW{ lon[n_SW], lat[n_SW] };
+            PointLonLat p_SE{ lon[n_SE], lat[n_SE] };
+            PointLonLat p_NW{ lon[n_NW], lat[n_NW] };
+            PointLonLat p_NE{ lon[n_NE], lat[n_NE] };
             p_SE.normalise( p_SW.lon() - 180. );
             p_NW.normalise( p_SW.lon() - 180. );
             p_NE.normalise( p_SW.lon() - 180. );
@@ -159,7 +159,7 @@ DetectInvalidElement::Statistics atlas::orca::OrcaData::detectInvalidElements( c
                         continue;
                     }
                 }
-                Flag{flags[n_SW]}.set( Flag::INVALID_ELEMENT );
+                Flag{ flags[n_SW] }.set( Flag::INVALID_ELEMENT );
             }
         }
     }

--- a/src/atlas-orca/util/OrcaData.cc
+++ b/src/atlas-orca/util/OrcaData.cc
@@ -22,8 +22,8 @@
 #include "atlas-orca/util/Flag.h"
 #include "atlas-orca/util/OrcaPeriodicity.h"
 
-namespace atlas {
-namespace orca {
+
+namespace atlas::orca {
 
 void OrcaData::setGhost() {
     idx_t ni = dimensions[0];
@@ -53,7 +53,7 @@ void OrcaData::makeHaloConsistent() {
     for ( size_t j = 0; j < nj; ++j ) {
         for ( size_t i = 0; i < ni; ++i ) {
             size_t n        = ni * j + i;
-            auto master     = compute_master( i, j );
+            auto master     = compute_master( static_cast<idx_t>( i ), static_cast<idx_t>( j ) );
             size_t n_master = ni * master.j + master.i;
             if ( n_master != n ) {
                 if ( lon[n] != lon[n_master] || lat[n] != lat[n_master] ) {
@@ -105,7 +105,7 @@ DetectInvalidElement::Statistics atlas::orca::OrcaData::detectInvalidElements( c
     idx_t ni          = dimensions[0];
     idx_t nj          = dimensions[1];
     idx_t nx          = ni - halo[HALO_EAST] - halo[HALO_WEST];
-    double resolution = 360. / double( nx );
+    double resolution = 360. / static_cast<double>( nx );
 
     util::Config detection_config;
     detection_config.set( "ORCA2", ( std::abs( resolution - 2. ) < 0.1 ) );
@@ -147,7 +147,8 @@ DetectInvalidElement::Statistics atlas::orca::OrcaData::detectInvalidElements( c
                     }
                     else {
                         for ( int k = invalid_factor - 1; k >= diagonal_factor; --k ) {
-                            if ( detect.diagonal_too_large( p_SW, p_SE, p_NE, p_NW, double( k ) * resolution ) ) {
+                            if ( detect.diagonal_too_large( p_SW, p_SE, p_NE, p_NW,
+                                                            static_cast<double>( k ) * resolution ) ) {
                                 Log::warning() << "Element {I,J} = {" << i << "," << j
                                                << "} is not invalidated as it contains water, even though (diagonal > "
                                                << diagonal_factor << " * ref_length)." << std::endl;
@@ -199,5 +200,4 @@ size_t atlas::orca::OrcaData::write( const eckit::PathName& path, const util::Co
 }
 
 
-}  // namespace orca
-}  // namespace atlas
+}  // namespace atlas::orca

--- a/src/atlas-orca/util/OrcaData.cc
+++ b/src/atlas-orca/util/OrcaData.cc
@@ -11,8 +11,7 @@
 #include "OrcaData.h"
 
 #include "eckit/log/ProgressTimer.h"
-
-#include "atlas/io/atlas-io.h"
+#include "eckit/codec/codec.h"
 
 #include "atlas/runtime/Log.h"
 #include "atlas/runtime/Trace.h"
@@ -187,15 +186,15 @@ void atlas::orca::OrcaData::checkSetup() {
 
 size_t atlas::orca::OrcaData::write( const eckit::PathName& path, const util::Config& config ) {
     checkSetup();
-    io::RecordWriter record;
+    eckit::codec::RecordWriter record;
     record.compression( config.getString( "compression", "none" ) );
     record.set( "version", 0 );
-    record.set( "dimensions", io::ref( dimensions ) );
-    record.set( "halo", io::ref( halo ) );
-    record.set( "pivot", io::ref( pivot ) );
-    record.set( "longitude", io::ArrayReference( lon.data(), dimensions ) );
-    record.set( "latitude", io::ArrayReference( lat.data(), dimensions ) );
-    record.set( "flags", io::ArrayReference( flags.data(), dimensions ) );
+    record.set( "dimensions", eckit::codec::ref( dimensions ) );
+    record.set( "halo", eckit::codec::ref( halo ) );
+    record.set( "pivot", eckit::codec::ref( pivot ) );
+    record.set( "longitude", eckit::codec::ArrayReference( lon.data(), dimensions ) );
+    record.set( "latitude", eckit::codec::ArrayReference( lat.data(), dimensions ) );
+    record.set( "flags", eckit::codec::ArrayReference( flags.data(), dimensions ) );
     return record.write( path );
 }
 

--- a/src/atlas-orca/util/OrcaData.h
+++ b/src/atlas-orca/util/OrcaData.h
@@ -29,9 +29,9 @@ namespace orca {
 
 class OrcaData {
 public:
-    std::array<std::int32_t, 2> dimensions{-1, -1};
-    std::array<std::int32_t, 4> halo{-1, -1, -1, -1};
-    std::array<double, 2> pivot{-1, -1};
+    std::array<std::int32_t, 2> dimensions{ -1, -1 };
+    std::array<std::int32_t, 4> halo{ -1, -1, -1, -1 };
+    std::array<double, 2> pivot{ -1, -1 };
     std::vector<double> lon;
     std::vector<double> lat;
     std::vector<std::byte> flags;

--- a/src/atlas-orca/util/OrcaData.h
+++ b/src/atlas-orca/util/OrcaData.h
@@ -22,8 +22,8 @@
 
 #include "atlas-orca/util/DetectInvalidElements.h"
 
-namespace atlas {
-namespace orca {
+
+namespace atlas::orca {
 
 //------------------------------------------------------------------------------------------------------
 
@@ -51,5 +51,4 @@ public:
 
 //------------------------------------------------------------------------------------------------------
 
-}  // namespace orca
-}  // namespace atlas
+}  // namespace atlas::orca

--- a/src/atlas-orca/util/OrcaDataFile.cc
+++ b/src/atlas-orca/util/OrcaDataFile.cc
@@ -1,0 +1,100 @@
+/*
+ * (C) Copyright 2021- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include "atlas-orca/util/OrcaDataFile.h"
+
+#include <sstream>
+#include <vector>
+
+#include "atlas/runtime/Log.h"
+#include "eckit/utils/Tokenizer.h"
+
+#include "atlas/parallel/mpi/mpi.h"
+#include "atlas/runtime/Exception.h"
+
+#include "atlas-orca/Library.h"
+#include "atlas-orca/util/ComputeCachedPath.h"
+#include "atlas-orca/util/Download.h"
+
+
+namespace atlas::orca {
+
+OrcaDataFile::OrcaDataFile( const std::string& uri, const std::string& checksum ) : uri_( uri ), checksum_( checksum ) {
+    static const std::vector<std::string> KNOWN_URLS{
+        "http://get.ecmwf.int/repository/atlas/grids/orca",
+        "https://get.ecmwf.int/repository/atlas/grids/orca",
+    };
+
+    static const std::vector<std::string> SEARCH_PATHS = []() {
+        std::vector<std::string> paths;
+        eckit::Tokenizer( ":", false )( Library::instance().dataPath(), paths );
+        if ( Library::instance().caching() ) {
+            paths.emplace_back( Library::instance().cachePath() );
+        }
+        return paths;
+    }();
+
+    auto file_search = FileSearch{ SEARCH_PATHS, KNOWN_URLS };
+
+    if ( uri_.scheme().find( "http" ) == 0 ) {
+        auto url = uri_.asRawString();
+
+        Log::debug() << "Looking for " << file_search.file( url ) << " in " << file_search.searchPath() << std::endl;
+        int found = 0;
+        if ( mpi::comm().rank() == 0 ) {
+            found = file_search( url, path_ ) ? 1 : 0;
+        }
+        mpi::comm().broadcast( found, 0 );
+        if ( found == 0 ) {
+            Log::debug() << "File " << uri << " has not been found in " << file_search.searchPath() << std::endl;
+        }
+        if ( found == 1 ) {
+            if ( mpi::comm().rank() != 0 ) {
+                // Find path also on non-zero ranks
+                ATLAS_ASSERT( file_search( url, path_ ) );
+            }
+            Log::debug() << "File " << uri << " has been found: " << path_ << std::endl;
+        }
+        else if ( Library::instance().caching() ) {
+            path_ = ComputeCachedPath{ KNOWN_URLS }( url );
+
+            Log::debug() << "Caching enabled. Downloading " << uri << " to " << path_ << std::endl;
+
+            if ( mpi::comm().rank() == 0 ) {
+                if ( download( url, path_ ) == 0 ) {
+                    ATLAS_THROW_EXCEPTION( "Could not download file from url " << url );
+                }
+                if ( not path_.exists() ) {
+                    ATLAS_THROW_EXCEPTION( "Could not locate orca grid data file " << path_ );
+                }
+            }
+            mpi::comm().barrier();
+        }
+        else {
+            ATLAS_THROW_EXCEPTION( "Could not locate orca grid data file " << file_search.file( url ) << " in "
+                                                                           << file_search.searchPath() );
+        }
+    }
+    else {
+        path_      = uri_.path();
+        auto found = path_.exists();
+        if ( not found ) {
+            found = file_search( uri_.path(), path_ );
+            if ( found ) {
+                Log::debug() << "File " << uri << " has been found: " << path_ << std::endl;
+            }
+        }
+        if ( not found ) {
+            ATLAS_THROW_EXCEPTION( "Could not locate orca grid data file " << uri );
+        }
+    }
+}
+
+}  // namespace atlas::orca

--- a/src/atlas-orca/util/OrcaDataFile.h
+++ b/src/atlas-orca/util/OrcaDataFile.h
@@ -33,22 +33,22 @@ namespace orca {
 
 static std::vector<std::string> known_urls() {
     std::vector<std::string> urls;
-    urls.emplace_back("http://get.ecmwf.int/repository/atlas/grids/orca");
-    urls.emplace_back("https://get.ecmwf.int/repository/atlas/grids/orca");
+    urls.emplace_back( "http://get.ecmwf.int/repository/atlas/grids/orca" );
+    urls.emplace_back( "https://get.ecmwf.int/repository/atlas/grids/orca" );
     return urls;
 }
 
 static std::vector<std::string> search_paths() {
     std::vector<std::string> paths;
-    eckit::Tokenizer tokenize(":");
+    eckit::Tokenizer tokenize( ":" );
     std::vector<std::string> tokenized;
-    tokenize( Library::instance().dataPath(), tokenized);
-    for( auto& t : tokenized ) {
-        if( not t.empty() ) {
-            paths.push_back(t);
+    tokenize( Library::instance().dataPath(), tokenized );
+    for ( auto& t : tokenized ) {
+        if ( not t.empty() ) {
+            paths.push_back( t );
         }
     }
-    if( Library::instance().caching() ) {
+    if ( Library::instance().caching() ) {
         paths.push_back( Library::instance().cachePath() );
     }
     return paths;
@@ -58,35 +58,36 @@ static std::vector<std::string> search_paths() {
 class OrcaDataFile {
 public:
     OrcaDataFile( const std::string& uri, const std::string& checksum = "" ) {
-        uri_      = eckit::URI( uri );
-        checksum_ = checksum;
-        auto file_search = FileSearch{search_paths(),known_urls()};
+        uri_             = eckit::URI( uri );
+        checksum_        = checksum;
+        auto file_search = FileSearch{ search_paths(), known_urls() };
         if ( uri_.scheme().find( "http" ) == 0 ) {
             std::string url = uri_.asRawString();
 
-            Log::debug() << "Looking for " << file_search.file(url) << " in " << file_search.searchPath() << std::endl;
+            Log::debug() << "Looking for " << file_search.file( url ) << " in " << file_search.searchPath()
+                         << std::endl;
             int found = 0;
             if ( mpi::comm().rank() == 0 ) {
                 found = file_search( url, path_ );
             }
-            mpi::comm().broadcast(found,0);
-            if( not found ) {
+            mpi::comm().broadcast( found, 0 );
+            if ( not found ) {
                 Log::debug() << "File " << uri << " has not been found in " << file_search.searchPath() << std::endl;
             }
-            if( found ) {
-                if( mpi::comm().rank() != 0 ) {
+            if ( found ) {
+                if ( mpi::comm().rank() != 0 ) {
                     // Find path also on non-zero ranks
                     ATLAS_ASSERT( file_search( url, path_ ) );
                 }
                 Log::debug() << "File " << uri << " has been found: " << path_ << std::endl;
             }
             else if ( Library::instance().caching() ) {
-                path_ = ComputeCachedPath{known_urls()}(url);
+                path_ = ComputeCachedPath{ known_urls() }( url );
 
                 Log::debug() << "Caching enabled. Downloading " << uri << " to " << path_ << std::endl;
 
                 if ( mpi::comm().rank() == 0 ) {
-                   if ( download( url, path_ ) == 0 ) {
+                    if ( download( url, path_ ) == 0 ) {
                         std::stringstream errmsg;
                         errmsg << "Could not download file from url " << url;
                         ATLAS_THROW_EXCEPTION( errmsg.str() );
@@ -98,20 +99,21 @@ public:
                 mpi::comm().barrier();
             }
             else {
-                ATLAS_THROW_EXCEPTION( "Could not locate orca grid data file " << file_search.file(url) << " in " << file_search.searchPath() );
+                ATLAS_THROW_EXCEPTION( "Could not locate orca grid data file " << file_search.file( url ) << " in "
+                                                                               << file_search.searchPath() );
             }
         }
         else {
             bool found;
             path_ = uri_.path();
             found = path_.exists();
-            if( not found ) {
+            if ( not found ) {
                 found = file_search( uri_.path(), path_ );
-                if( found ) {
+                if ( found ) {
                     Log::debug() << "File " << uri << " has been found: " << path_ << std::endl;
                 }
             }
-            if( not found ) {
+            if ( not found ) {
                 ATLAS_THROW_EXCEPTION( "Could not locate orca grid data file " << uri );
             }
         }

--- a/src/atlas-orca/util/OrcaDataFile.h
+++ b/src/atlas-orca/util/OrcaDataFile.h
@@ -10,112 +10,16 @@
 
 #pragma once
 
-#include "atlas-orca/Library.h"
-
-#include <sstream>
-#include <vector>
+#include <string>
 
 #include "eckit/filesystem/PathName.h"
 #include "eckit/filesystem/URI.h"
-#include "eckit/utils/Tokenizer.h"
-
-#include "atlas/parallel/mpi/mpi.h"
-#include "atlas/runtime/Exception.h"
-#include "atlas/runtime/Log.h"
-#include "atlas/runtime/Trace.h"
-
-#include "atlas-orca/util/ComputeCachedPath.h"
-#include "atlas-orca/util/Download.h"
-
 
 namespace atlas::orca {
 
-static std::vector<std::string> known_urls() {
-    std::vector<std::string> urls;
-    urls.emplace_back( "http://get.ecmwf.int/repository/atlas/grids/orca" );
-    urls.emplace_back( "https://get.ecmwf.int/repository/atlas/grids/orca" );
-    return urls;
-}
-
-static std::vector<std::string> search_paths() {
-    std::vector<std::string> paths;
-    eckit::Tokenizer tokenize( ":" );
-    std::vector<std::string> tokenized;
-    tokenize( Library::instance().dataPath(), tokenized );
-    for ( const auto& t : tokenized ) {
-        if ( not t.empty() ) {
-            paths.push_back( t );
-        }
-    }
-    if ( Library::instance().caching() ) {
-        paths.push_back( Library::instance().cachePath() );
-    }
-    return paths;
-}
-
-
 class OrcaDataFile {
 public:
-    explicit OrcaDataFile( const std::string& uri, const std::string& checksum = "" ) :
-        uri_( uri ), checksum_( checksum ) {
-        auto file_search = FileSearch{ search_paths(), known_urls() };
-
-        if ( uri_.scheme().find( "http" ) == 0 ) {
-            std::string url = uri_.asRawString();
-
-            Log::debug() << "Looking for " << file_search.file( url ) << " in " << file_search.searchPath()
-                         << std::endl;
-            int found = 0;
-            if ( mpi::comm().rank() == 0 ) {
-                found = file_search( url, path_ ) ? 1 : 0;
-            }
-            mpi::comm().broadcast( found, 0 );
-            if ( found == 0 ) {
-                Log::debug() << "File " << uri << " has not been found in " << file_search.searchPath() << std::endl;
-            }
-            if ( found == 1 ) {
-                if ( mpi::comm().rank() != 0 ) {
-                    // Find path also on non-zero ranks
-                    ATLAS_ASSERT( file_search( url, path_ ) );
-                }
-                Log::debug() << "File " << uri << " has been found: " << path_ << std::endl;
-            }
-            else if ( Library::instance().caching() ) {
-                path_ = ComputeCachedPath{ known_urls() }( url );
-
-                Log::debug() << "Caching enabled. Downloading " << uri << " to " << path_ << std::endl;
-
-                if ( mpi::comm().rank() == 0 ) {
-                    if ( download( url, path_ ) == 0 ) {
-                        std::stringstream errmsg;
-                        errmsg << "Could not download file from url " << url;
-                        ATLAS_THROW_EXCEPTION( errmsg.str() );
-                    }
-                    if ( not path_.exists() ) {
-                        ATLAS_THROW_EXCEPTION( "Could not locate orca grid data file " << path_ );
-                    }
-                }
-                mpi::comm().barrier();
-            }
-            else {
-                ATLAS_THROW_EXCEPTION( "Could not locate orca grid data file " << file_search.file( url ) << " in "
-                                                                               << file_search.searchPath() );
-            }
-        }
-        else {
-            path_      = uri_.path();
-            auto found = path_.exists();
-            if ( not found ) {
-                found = file_search( uri_.path(), path_ );
-                if ( found ) {
-                    Log::debug() << "File " << uri << " has been found: " << path_ << std::endl;
-                }
-            }
-            if ( not found ) {
-                ATLAS_THROW_EXCEPTION( "Could not locate orca grid data file " << uri );
-            }
-        }
-    }
+    explicit OrcaDataFile( const std::string& uri, const std::string& checksum = "" );
 
     const eckit::PathName& path() const { return path_; }
 

--- a/src/atlas-orca/util/OrcaPeriodicity.cc
+++ b/src/atlas-orca/util/OrcaPeriodicity.cc
@@ -24,10 +24,10 @@ OrcaPeriodicity::OrcaPeriodicity( const OrcaData& orca ) : OrcaPeriodicity( orca
 
 OrcaPeriodicity::OrcaPeriodicity( const std::array<std::int32_t, 2>& dimensions,
                                   const std::array<std::int32_t, 4>& halo, const std::array<double, 2>& pivot ) :
-    nx_{dimensions[0] - halo_[HALO_WEST] - halo_[HALO_EAST]},
-    ny_{dimensions[0] - halo_[HALO_WEST] - halo_[HALO_EAST]},
-    halo_{halo},
-    pivot_{pivot} {
+    nx_{ dimensions[0] - halo_[HALO_WEST] - halo_[HALO_EAST] },
+    ny_{ dimensions[0] - halo_[HALO_WEST] - halo_[HALO_EAST] },
+    halo_{ halo },
+    pivot_{ pivot } {
     ibegin_ = halo_[HALO_WEST];
     iend_   = ibegin_ + nx_;
 }

--- a/src/atlas-orca/util/OrcaPeriodicity.cc
+++ b/src/atlas-orca/util/OrcaPeriodicity.cc
@@ -17,8 +17,8 @@
 #include "atlas-orca/util/OrcaData.h"
 #include "atlas-orca/util/PointIJ.h"
 #include "atlas/library/config.h"
-namespace atlas {
-namespace orca {
+
+namespace atlas::orca {
 
 OrcaPeriodicity::OrcaPeriodicity( const OrcaData& orca ) : OrcaPeriodicity( orca.dimensions, orca.halo, orca.pivot ) {}
 
@@ -26,15 +26,13 @@ OrcaPeriodicity::OrcaPeriodicity( const std::array<std::int32_t, 2>& dimensions,
                                   const std::array<std::int32_t, 4>& halo, const std::array<double, 2>& pivot ) :
     nx_{ dimensions[0] - halo_[HALO_WEST] - halo_[HALO_EAST] },
     ny_{ dimensions[0] - halo_[HALO_WEST] - halo_[HALO_EAST] },
+    ibegin_( halo_[HALO_WEST] ),
+    iend_( ibegin_ + nx_ ),
     halo_{ halo },
-    pivot_{ pivot } {
-    ibegin_ = halo_[HALO_WEST];
-    iend_   = ibegin_ + nx_;
-}
+    pivot_{ pivot } {}
 
 //------------------------------------------------------------------------------------------------------
 
 //------------------------------------------------------------------------------------------------------
 
-}  // namespace orca
-}  // namespace atlas
+}  // namespace atlas::orca

--- a/src/atlas-orca/util/OrcaPeriodicity.h
+++ b/src/atlas-orca/util/OrcaPeriodicity.h
@@ -16,8 +16,8 @@
 #include "atlas-orca/util/PointIJ.h"
 #include "atlas/library/config.h"
 
-namespace atlas {
-namespace orca {
+
+namespace atlas::orca {
 
 //------------------------------------------------------------------------------------------------------
 
@@ -33,7 +33,7 @@ private:
     idx_t iend_;
 
 public:
-    OrcaPeriodicity( const OrcaData& orca );
+    explicit OrcaPeriodicity( const OrcaData& orca );
 
     OrcaPeriodicity( const std::array<std::int32_t, 2>& dimensions, const std::array<std::int32_t, 4>& halo,
                      const std::array<double, 2>& pivot );
@@ -50,9 +50,10 @@ public:
         if ( i >= iend_ ) {
             master.i -= nx_;
         }
-        if ( double( master.j ) > pivot_[1] || ( double( master.j ) == pivot_[1] && double( master.i ) > pivot_[0] ) ) {
-            master.i = idx_t( 2. * pivot_[0] ) - master.i;
-            master.j = idx_t( 2. * pivot_[1] ) - master.j;
+        if ( static_cast<double>( master.j ) > pivot_[1] ||
+             ( static_cast<double>( master.j ) == pivot_[1] && static_cast<double>( master.i ) > pivot_[0] ) ) {
+            master.i = static_cast<idx_t>( 2. * pivot_[0] ) - master.i;
+            master.j = static_cast<idx_t>( 2. * pivot_[1] ) - master.j;
             if ( master.i < ibegin_ ) {
                 master.i += nx_;
             }
@@ -64,5 +65,4 @@ public:
     }
 };
 
-}  // namespace orca
-}  // namespace atlas
+}  // namespace atlas::orca

--- a/src/atlas-orca/util/OrcaPeriodicity.h
+++ b/src/atlas-orca/util/OrcaPeriodicity.h
@@ -43,7 +43,7 @@ public:
     PointIJ operator()( idx_t i, idx_t j ) const { return compute( i, j ); }
 
     PointIJ compute( idx_t i, idx_t j ) const {
-        PointIJ master{i, j};
+        PointIJ master{ i, j };
         if ( i < ibegin_ ) {
             master.i += nx_;
         }

--- a/src/atlas-orca/util/PointIJ.h
+++ b/src/atlas-orca/util/PointIJ.h
@@ -14,8 +14,8 @@
 
 #include "atlas/library/config.h"
 
-namespace atlas {
-namespace orca {
+
+namespace atlas::orca {
 
 //------------------------------------------------------------------------------------------------------
 
@@ -52,5 +52,4 @@ struct PointIJ {
 
 //------------------------------------------------------------------------------------------------------
 
-}  // namespace orca
-}  // namespace atlas
+}  // namespace atlas::orca

--- a/src/tests/AtlasTestEnvironment.h
+++ b/src/tests/AtlasTestEnvironment.h
@@ -42,7 +42,7 @@ namespace test {
 using eckit::types::is_approximately_equal;
 
 class Test;
-static Test* current_test_{nullptr};
+static Test* current_test_{ nullptr };
 
 static size_t ATLAS_MAX_FAILED_EXPECTS() {
     static size_t v = size_t( eckit::Resource<long>( "$ATLAS_MAX_FAILED_EXPECTS", 100 ) );
@@ -62,7 +62,7 @@ public:
     }
     ~Test() { current_test_ = nullptr; }
     void expect_failed( const std::string& message, const eckit::CodeLocation& location ) {
-        failures_.emplace_back( Failure{message, location} );
+        failures_.emplace_back( Failure{ message, location } );
         eckit::Log::error() << message << std::endl;
         if ( failures_.size() == ATLAS_MAX_FAILED_EXPECTS() ) {
             std::stringstream msg;
@@ -180,7 +180,7 @@ struct Printer<PointLonLat> {
 template <>
 struct Printer<eckit::CodeLocation> {
     static void print( std::ostream& out, const eckit::CodeLocation& location ) {
-        out << eckit::PathName{location.file()}.baseName() << " +" << location.line();
+        out << eckit::PathName{ location.file() }.baseName() << " +" << location.line();
     }
 };
 

--- a/src/tests/test_orca_grid.cc
+++ b/src/tests/test_orca_grid.cc
@@ -32,7 +32,7 @@ CASE( "test orca grid iterator" ) {
     };
 
     std::vector<Section> sections{
-        {"ORCA2_T", 27118}, {"eORCA1_T", 120184},
+        { "ORCA2_T", 27118 }, { "eORCA1_T", 120184 },
         //{"ORCA025_T", 1472282},
     };
     for ( auto& section : sections ) {

--- a/src/tests/test_orca_grid.cc
+++ b/src/tests/test_orca_grid.cc
@@ -20,8 +20,8 @@
 using Grid   = atlas::Grid;
 using Config = atlas::util::Config;
 
-namespace atlas {
-namespace test {
+
+namespace atlas::test {
 
 //-----------------------------------------------------------------------------
 
@@ -42,12 +42,13 @@ CASE( "test orca grid iterator" ) {
 
             EXPECT_EQ( grid.size(), section.size );
 
-            Log::info() << "grid.footprint() = " << eckit::Bytes( grid.footprint() ) << std::endl;
+            Log::info() << "grid.footprint() = " << eckit::Bytes( static_cast<double>( grid.footprint() ) )
+                        << std::endl;
 
             idx_t n = 0;
             {
                 auto trace = Trace( Here(), "iterating" );
-                for ( auto& p : grid.lonlat() ) {
+                for ( const auto& p : grid.lonlat() ) {
                     ++n;
                 }
                 trace.stop();
@@ -62,8 +63,8 @@ CASE( "test orca grid iterator" ) {
 
 //-----------------------------------------------------------------------------
 
-}  // namespace test
-}  // namespace atlas
+}  // namespace atlas::test
+
 
 int main( int argc, char** argv ) {
     return atlas::test::run( argc, argv );

--- a/src/tests/test_orca_grid_specs.cc
+++ b/src/tests/test_orca_grid_specs.cc
@@ -12,8 +12,8 @@
 
 #include "tests/AtlasTestEnvironment.h"
 
-namespace atlas {
-namespace test {
+
+namespace atlas::test {
 
 //-----------------------------------------------------------------------------
 
@@ -64,8 +64,8 @@ CASE( "test spec" ) {
 
 //-----------------------------------------------------------------------------
 
-}  // namespace test
-}  // namespace atlas
+}  // namespace atlas::test
+
 
 int main( int argc, char** argv ) {
     return atlas::test::run( argc, argv );

--- a/src/tests/test_orca_grid_specs.cc
+++ b/src/tests/test_orca_grid_specs.cc
@@ -38,9 +38,9 @@ CASE( "test spec" ) {
     std::vector<std::string> uids;
     std::map<std::string, std::string> check_name;
 
-    std::vector<std::string> grids{"ORCA2", "ORCA1", "eORCA1", "ORCA025", "eORCA025", "ORCA12", "eORCA12"};
+    std::vector<std::string> grids{ "ORCA2", "ORCA1", "eORCA1", "ORCA025", "eORCA025", "ORCA12", "eORCA12" };
     for ( const auto& grid : grids ) {
-        std::vector<std::string> arrangements{"F", "T", "U", "V", "W"};
+        std::vector<std::string> arrangements{ "F", "T", "U", "V", "W" };
         for ( const auto& P : arrangements ) {
             std::string name = grid + "_" + P;
             EXPECT( registered( name ) );

--- a/src/tests/test_orca_mesh.cc
+++ b/src/tests/test_orca_mesh.cc
@@ -30,8 +30,8 @@
 using Grid   = atlas::Grid;
 using Config = atlas::util::Config;
 
-namespace atlas {
-namespace test {
+
+namespace atlas::test {
 
 //-----------------------------------------------------------------------------
 
@@ -46,19 +46,19 @@ CASE( "test generate orca mesh" ) {
     static auto grid            = Grid( gridname );
 
     SECTION( "orca_generate" ) {
-        Log::info() << "grid.footprint() = " << eckit::Bytes( grid.footprint() ) << std::endl;
+        Log::info() << "grid.footprint() = " << eckit::Bytes( static_cast<double>( grid.footprint() ) ) << std::endl;
 
         auto meshgenerator = MeshGenerator{ "orca" };
         auto mesh          = meshgenerator.generate( grid );
-        Log::info() << "mesh.footprint() = " << eckit::Bytes( mesh.footprint() ) << std::endl;
+        Log::info() << "mesh.footprint() = " << eckit::Bytes( static_cast<double>( mesh.footprint() ) ) << std::endl;
 
         EXPECT_EQ( mesh.nodes().size(), grid.size() );
 
-        if ( mesh.footprint() < 25 * 1e6 ) {  // less than 25 Mb
+        if ( static_cast<double>( mesh.footprint() ) < 25.e6 ) {  // less than 25 Mb
             output::Gmsh{ "orca_2d.msh", Config( "coordinates", "lonlat" ) }.write( mesh );
             output::Gmsh{ "orca_3d.msh", Config( "coordinates", "xyz" ) }.write( mesh );
         }
-        ATLAS_DEBUG( "Peak memory: " << eckit::Bytes( peakMemory() ) );
+        ATLAS_DEBUG( "Peak memory: " << eckit::Bytes( static_cast<double>( peakMemory() ) ) );
     }
 
     SECTION( "auto_generate" ) {
@@ -90,7 +90,7 @@ CASE( "test orca mesh halo" ) {
             for ( idx_t jnode = 0; jnode < mesh.nodes().size(); ++jnode ) {
                 if ( remote_idx( jnode ) < 0 ) {
                     auto p = orca::PointIJ{ ij( jnode, 0 ), ij( jnode, 1 ) };
-                    orca::PointIJ master;
+                    orca::PointIJ master{};
                     grid->index2ij( grid->periodicIndex( p.i, p.j ), master.i, master.j );
                     Log::info() << p << " --> " << master << std::endl;
                     ++count;
@@ -114,8 +114,8 @@ CASE( "test orca mesh halo" ) {
 
 //-----------------------------------------------------------------------------
 
-}  // namespace test
-}  // namespace atlas
+}  // namespace atlas::test
+
 
 int main( int argc, char** argv ) {
     return atlas::test::run( argc, argv );

--- a/src/tests/test_orca_mesh.cc
+++ b/src/tests/test_orca_mesh.cc
@@ -48,20 +48,22 @@ CASE( "test generate orca mesh" ) {
     SECTION( "orca_generate" ) {
         Log::info() << "grid.footprint() = " << eckit::Bytes( grid.footprint() ) << std::endl;
 
-        auto meshgenerator = MeshGenerator{"orca"};
+        auto meshgenerator = MeshGenerator{ "orca" };
         auto mesh          = meshgenerator.generate( grid );
         Log::info() << "mesh.footprint() = " << eckit::Bytes( mesh.footprint() ) << std::endl;
 
         EXPECT_EQ( mesh.nodes().size(), grid.size() );
 
         if ( mesh.footprint() < 25 * 1e6 ) {  // less than 25 Mb
-            output::Gmsh{"orca_2d.msh", Config( "coordinates", "lonlat" )}.write( mesh );
-            output::Gmsh{"orca_3d.msh", Config( "coordinates", "xyz" )}.write( mesh );
+            output::Gmsh{ "orca_2d.msh", Config( "coordinates", "lonlat" ) }.write( mesh );
+            output::Gmsh{ "orca_3d.msh", Config( "coordinates", "xyz" ) }.write( mesh );
         }
         ATLAS_DEBUG( "Peak memory: " << eckit::Bytes( peakMemory() ) );
     }
 
-    SECTION( "auto_generate" ) { auto mesh = Mesh{grid}; }
+    SECTION( "auto_generate" ) {
+        auto mesh = Mesh{ grid };
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -74,20 +76,20 @@ CASE( "test orca mesh halo" ) {
     };
     for ( auto gridname : gridnames ) {
         SECTION( gridname ) {
-            auto mesh = Mesh{Grid( gridname )};
+            auto mesh = Mesh{ Grid( gridname ) };
             REQUIRE( mesh.grid() );
             EXPECT( mesh.grid().name() == gridname );
             auto remote_idx = array::make_indexview<idx_t, 1>( mesh.nodes().remote_index() );
             auto ij         = array::make_view<idx_t, 2>( mesh.nodes().field( "ij" ) );
-            idx_t count{0};
+            idx_t count{ 0 };
 
-            functionspace::NodeColumns fs{mesh};
+            functionspace::NodeColumns fs{ mesh };
             Field field   = fs.createField<double>( option::name( "bla" ) );
             auto f        = array::make_view<double, 1>( field );
             OrcaGrid grid = mesh.grid();
             for ( idx_t jnode = 0; jnode < mesh.nodes().size(); ++jnode ) {
                 if ( remote_idx( jnode ) < 0 ) {
-                    auto p = orca::PointIJ{ij( jnode, 0 ), ij( jnode, 1 )};
+                    auto p = orca::PointIJ{ ij( jnode, 0 ), ij( jnode, 1 ) };
                     orca::PointIJ master;
                     grid->index2ij( grid->periodicIndex( p.i, p.j ), master.i, master.j );
                     Log::info() << p << " --> " << master << std::endl;

--- a/src/tests/test_orca_mesh_boundaries.cc
+++ b/src/tests/test_orca_mesh_boundaries.cc
@@ -11,14 +11,14 @@
 #include <numeric>
 #include <sstream>
 
+#include "atlas-orca/meshgenerator/OrcaMeshGenerator.h"
 #include "atlas/functionspace/NodeColumns.h"
 #include "atlas/grid.h"
 #include "atlas/mesh.h"
 #include "atlas/meshgenerator.h"
-#include "atlas-orca/meshgenerator/OrcaMeshGenerator.h"
+#include "atlas/output/Gmsh.h"
 #include "atlas/util/Config.h"
 #include "atlas/util/function/VortexRollup.h"
-#include "atlas/output/Gmsh.h"
 
 #include "atlas/util/Geometry.h"
 #include "atlas/util/LonLatMicroDeg.h"
@@ -44,88 +44,87 @@ CASE( "test haloExchange " ) {
         "ORCA2_U",   //
         "ORCA2_V",   //
         "eORCA1_T",  //
-//        "eORCA025_T",  //
-//        "eORCA12_T",  //
+                     //        "eORCA025_T",  //
+                     //        "eORCA12_T",  //
     };
     auto distributionNames = std::vector<std::string>{
-      "serial",
-      "checkerboard",
-      "equal_regions",  //
+        "serial", "checkerboard",
+        "equal_regions",  //
     };
 
-    auto rollup_plus = [](const double lon, const double lat) {
-      return 1 + util::function::vortex_rollup(lon, lat, 0.0);
+    auto rollup_plus = []( const double lon, const double lat ) {
+        return 1 + util::function::vortex_rollup( lon, lat, 0.0 );
     };
 
     for ( auto distributionName : distributionNames ) {
         for ( auto gridname : gridnames ) {
             for ( int64_t halo = 0; halo < 1; ++halo ) {
-                SECTION( gridname + "_" + distributionName + "_halo" + std::to_string(halo) ) {
-                    auto grid = Grid(gridname);
-                    auto meshgen_config = grid.meshgenerator() | option::halo(halo);
-                    atlas::MeshGenerator meshgen(meshgen_config);
+                SECTION( gridname + "_" + distributionName + "_halo" + std::to_string( halo ) ) {
+                    auto grid           = Grid( gridname );
+                    auto meshgen_config = grid.meshgenerator() | option::halo( halo );
+                    atlas::MeshGenerator meshgen( meshgen_config );
                     auto partitioner_config = grid.partitioner();
-                    partitioner_config.set("type", distributionName);
-                    auto partitioner = grid::Partitioner(partitioner_config);
-                    auto mesh = meshgen.generate(grid, partitioner);
+                    partitioner_config.set( "type", distributionName );
+                    auto partitioner = grid::Partitioner( partitioner_config );
+                    auto mesh        = meshgen.generate( grid, partitioner );
                     REQUIRE( mesh.grid() );
                     EXPECT( mesh.grid().name() == gridname );
-                    idx_t count{0};
+                    idx_t count{ 0 };
 
-                    const auto remote_idxs = array::make_indexview<idx_t, 1>(
-                                              mesh.nodes().remote_index());
-                    functionspace::NodeColumns fs(mesh, option::halo(halo));
+                    const auto remote_idxs = array::make_indexview<idx_t, 1>( mesh.nodes().remote_index() );
+                    functionspace::NodeColumns fs( mesh, option::halo( halo ) );
                     double halosize = 0;
-                    mesh.metadata().get("halo", halosize);
-                    EXPECT(halosize == halo);
+                    mesh.metadata().get( "halo", halosize );
+                    EXPECT( halosize == halo );
 
-                    Field field   = fs.createField<double>( option::name( "vortex rollup" ) );
-                    Field field2   = fs.createField<double>( option::name( "remotes < 0" ) );
-                    auto f        = array::make_view<double, 1>( field );
-                    auto f2        = array::make_view<double, 1>( field2 );
-                    const auto ghosts = atlas::array::make_view<int32_t, 1>(
-                                          mesh.nodes().ghost());
+                    Field field       = fs.createField<double>( option::name( "vortex rollup" ) );
+                    Field field2      = fs.createField<double>( option::name( "remotes < 0" ) );
+                    auto f            = array::make_view<double, 1>( field );
+                    auto f2           = array::make_view<double, 1>( field2 );
+                    const auto ghosts = atlas::array::make_view<int32_t, 1>( mesh.nodes().ghost() );
                     const auto lonlat = array::make_view<double, 2>( mesh.nodes().lonlat() );
                     for ( idx_t jnode = 0; jnode < mesh.nodes().size(); ++jnode ) {
-                        if (ghosts(jnode)) {
+                        if ( ghosts( jnode ) ) {
                             f( jnode ) = 0;
-                        } else {
-                            const double lon = lonlat(jnode, 0);
-                            const double lat = lonlat(jnode, 1);
-                            f( jnode ) = rollup_plus(lon, lat);
+                        }
+                        else {
+                            const double lon = lonlat( jnode, 0 );
+                            const double lat = lonlat( jnode, 1 );
+                            f( jnode )       = rollup_plus( lon, lat );
                         }
                     }
 
-                    fs.haloExchange(field);
+                    fs.haloExchange( field );
 
-                    const auto xy = array::make_view<double, 2>( mesh.nodes().xy() );
-                    const auto glb_idxs = array::make_view<gidx_t, 1>(mesh.nodes().global_index());
+                    const auto xy        = array::make_view<double, 2>( mesh.nodes().xy() );
+                    const auto glb_idxs  = array::make_view<gidx_t, 1>( mesh.nodes().global_index() );
                     const auto partition = array::make_view<int32_t, 1>( mesh.nodes().partition() );
-                    const auto halos = array::make_view<int32_t, 1>( mesh.nodes().halo() );
+                    const auto halos     = array::make_view<int32_t, 1>( mesh.nodes().halo() );
 
-                    const auto master_glb_idxs = array::make_view<gidx_t, 1>(
-                        mesh.nodes().field( "master_global_index" ) );
+                    const auto master_glb_idxs =
+                        array::make_view<gidx_t, 1>( mesh.nodes().field( "master_global_index" ) );
                     const auto ij = array::make_view<idx_t, 2>( mesh.nodes().field( "ij" ) );
 
-                    double sumSquares{0.0};
+                    double sumSquares{ 0.0 };
                     for ( idx_t jnode = 0; jnode < mesh.nodes().size(); ++jnode ) {
-                        f2(jnode) = 0;
-                        const double lon = lonlat(jnode, 0);
-                        const double lat = lonlat(jnode, 1);
-                        if (std::abs(f(jnode) - rollup_plus(lon, lat)) > 1e-6) {
-                          f(jnode) = -1;
-                          sumSquares += std::pow(std::abs(f(jnode) - rollup_plus(lon, lat)), 2);
-                          ++count;
+                        f2( jnode )      = 0;
+                        const double lon = lonlat( jnode, 0 );
+                        const double lat = lonlat( jnode, 1 );
+                        if ( std::abs( f( jnode ) - rollup_plus( lon, lat ) ) > 1e-6 ) {
+                            f( jnode ) = -1;
+                            sumSquares += std::pow( std::abs( f( jnode ) - rollup_plus( lon, lat ) ), 2 );
+                            ++count;
                         }
-                        if (remote_idxs(jnode) < 0) {
-                          std::cout << "[" << mpi::rank() << "] remote_idx < 0 " << jnode
-                                    << " : ghost " << ghosts(jnode) << " master_global_index " << master_glb_idxs(jnode)
-                                    << " lon " << lonlat(jnode, 0) << " lat " << lonlat(jnode, 1) << std::endl;
-                          f2(jnode) = 1;
+                        if ( remote_idxs( jnode ) < 0 ) {
+                            std::cout << "[" << mpi::rank() << "] remote_idx < 0 " << jnode << " : ghost "
+                                      << ghosts( jnode ) << " master_global_index " << master_glb_idxs( jnode )
+                                      << " lon " << lonlat( jnode, 0 ) << " lat " << lonlat( jnode, 1 ) << std::endl;
+                            f2( jnode ) = 1;
                         }
                     }
                     if ( count != 0 ) {
-                        Log::info() << "count nonzero and norm of differences is: " << std::sqrt(sumSquares) << std::endl;
+                        Log::info() << "count nonzero and norm of differences is: " << std::sqrt( sumSquares )
+                                    << std::endl;
                         Log::info() << "To diagnose problem, uncomment mesh writing here: " << Here() << std::endl;
                         // output::Gmsh gmsh(
                         //     std::string("haloExchange_")+gridname+"_"+distributionName+"_"+std::to_string(halo)+".msh",

--- a/src/tests/test_orca_plugin.cc
+++ b/src/tests/test_orca_plugin.cc
@@ -13,8 +13,8 @@
 
 #include "tests/AtlasTestEnvironment.h"
 
-namespace atlas {
-namespace test {
+
+namespace atlas::test {
 
 //-----------------------------------------------------------------------------
 
@@ -30,8 +30,8 @@ CASE( "test plugin" ) {
 
 //-----------------------------------------------------------------------------
 
-}  // namespace test
-}  // namespace atlas
+}  // namespace atlas::test
+
 
 int main( int argc, char** argv ) {
     return atlas::test::run( argc, argv );

--- a/src/tests/test_orca_polygon_locator.cc
+++ b/src/tests/test_orca_polygon_locator.cc
@@ -32,42 +32,40 @@ namespace test {
 //-----------------------------------------------------------------------------
 
 CASE( "test orca polygon locator" ) {
-
     auto gridnames = std::vector<std::string>{
-        "ORCA2_T",   //
-        "eORCA1_T",  //
+        "ORCA2_T",     //
+        "eORCA1_T",    //
         "eORCA025_T",  //
         // "eORCA12_T",  //
     };
 
     std::string grid_resource = eckit::Resource<std::string>( "--grid", "" );
     if ( not grid_resource.empty() ) {
-        gridnames = {grid_resource};
+        gridnames = { grid_resource };
     }
 
     for ( auto gridname : gridnames ) {
         SECTION( gridname ) {
-            OrcaGrid grid      = Grid( gridname );
-            grid::Partitioner partitioner("equal_regions", atlas::mpi::size());
-            auto meshgenerator = MeshGenerator{"orca"};
+            OrcaGrid grid = Grid( gridname );
+            grid::Partitioner partitioner( "equal_regions", atlas::mpi::size() );
+            auto meshgenerator = MeshGenerator{ "orca" };
             auto mesh          = meshgenerator.generate( grid, partitioner );
             REQUIRE( mesh.grid() );
             EXPECT( mesh.grid().name() == gridname );
-            atlas::util::ListPolygonXY polygon_list(mesh.polygons());
+            atlas::util::ListPolygonXY polygon_list( mesh.polygons() );
             //mesh.polygon(0).outputPythonScript("polygon.py",
             //                                   Config("nodes", false)("coordinates", "xy"));
-            atlas::util::PolygonLocator locator(polygon_list, mesh.projection());
+            atlas::util::PolygonLocator locator( polygon_list, mesh.projection() );
 
             // fails on ORCA2 because partition polygon is not connected space
             // (ORCA2 grids have a cut out area for the mediterranean)
             idx_t part;
-            part = locator({82.0, 10.0});
+            part = locator( { 82.0, 10.0 } );
             ATLAS_DEBUG_VAR( part );
             // would fail on ORCA025 because xy coordinate system doesn't cover
             // 0-360. A fix for this has been added to the locator in atlas 0.32.0.
-            part = locator({-173.767, -61.1718});
+            part = locator( { -173.767, -61.1718 } );
             ATLAS_DEBUG_VAR( part );
-
         }
     }
 }

--- a/src/tests/test_orca_valid_elements.cc
+++ b/src/tests/test_orca_valid_elements.cc
@@ -46,11 +46,11 @@ CASE( "test generate orca mesh" ) {
     bool gmsh_output          = eckit::Resource<bool>( "--gmsh", false );
     std::string grid_resource = eckit::Resource<std::string>( "--grid", "" );
     if ( not grid_resource.empty() ) {
-        gridnames = {grid_resource};
+        gridnames = { grid_resource };
     }
     for ( const auto& gridname : gridnames ) {
         SECTION( gridname ) {
-            auto mesh = Mesh{gridname};
+            auto mesh = Mesh{ gridname };
 
             const auto& connectivity = mesh.cells().node_connectivity();
             auto lonlat              = array::make_view<double, 2>( mesh.nodes().lonlat() );
@@ -68,10 +68,10 @@ CASE( "test generate orca mesh" ) {
                     std::array<PointLonLat, 4> pll;
                     std::array<PointXYZ, 4> pxyz;
                     for ( idx_t n = 0; n < 4; ++n ) {
-                        pll[n]  = PointLonLat{lonlat( connectivity( e, n ), 0 ), lonlat( connectivity( e, n ), 1 )};
+                        pll[n]  = PointLonLat{ lonlat( connectivity( e, n ), 0 ), lonlat( connectivity( e, n ), 1 ) };
                         pxyz[n] = geometry.xyz( pll[n] );
                     }
-                    Quad3D quad{pxyz[0], pxyz[1], pxyz[2], pxyz[3]};
+                    Quad3D quad{ pxyz[0], pxyz[1], pxyz[2], pxyz[3] };
                     if ( not quad.validate() ) {
                         has_invalid_quads = true;
                         Log::info() << "Invalid quad [" << elem_glb_idx( e ) << "] : [ " << connectivity( e, 0 ) + 1

--- a/src/tests/test_orca_valid_elements.cc
+++ b/src/tests/test_orca_valid_elements.cc
@@ -33,8 +33,8 @@ using Grid   = atlas::Grid;
 using Config = atlas::util::Config;
 using Quad3D = atlas::interpolation::element::Quad3D;
 
-namespace atlas {
-namespace test {
+
+namespace atlas::test {
 
 CASE( "test generate orca mesh" ) {
     std::vector<std::string> gridnames{
@@ -98,8 +98,8 @@ CASE( "test generate orca mesh" ) {
 
 //-----------------------------------------------------------------------------
 
-}  // namespace test
-}  // namespace atlas
+}  // namespace atlas::test
+
 
 int main( int argc, char** argv ) {
     return atlas::test::run( argc, argv );


### PR DESCRIPTION
This PR replaces the use of atlas::io for eckit::codec. As far as I can test eckit::coded it is a stright replacement to atlas::io, except for some deprecated compiler workarounds (which might need to be reinstated).

The PR is to avoid new code on MultIO using atlas::io, and to test before the ORCA in production deadline arrives.

Note that eckit::codec is configuration-time optional in eckit and disabled by default, which itself might be a decision to revisit. Also the target is develop, so we can prepare a release timely.