### PR TITLE
Refactor to allow halo > 0 decomposition of the mesh

### DIFF
--- a/src/atlas-orca/CMakeLists.txt
+++ b/src/atlas-orca/CMakeLists.txt
@@ -24,6 +24,10 @@ ecbuild_add_library(
         grid/OrcaGridBuilder.cc
         meshgenerator/OrcaMeshGenerator.cc
         meshgenerator/OrcaMeshGenerator.h
+        meshgenerator/SurroundingRectangle.cc
+        meshgenerator/SurroundingRectangle.h
+        meshgenerator/LocalOrcaGrid.cc
+        meshgenerator/LocalOrcaGrid.h
         util/AtlasIOReader.h
         util/ComputeCachedPath.h
         util/ComputeUid.h

--- a/src/atlas-orca/grid/Orca.cc
+++ b/src/atlas-orca/grid/Orca.cc
@@ -28,6 +28,7 @@
 #include "atlas-orca/util/OrcaData.h"
 #include "atlas-orca/util/OrcaDataFile.h"
 #include "atlas-orca/util/OrcaPeriodicity.h"
+#include "atlas-orca/util/PointIJ.h"
 
 
 namespace atlas::grid::detail::grid {
@@ -81,6 +82,10 @@ std::string Orca::type() const {
 gidx_t Orca::periodicIndex( idx_t i, idx_t j ) const {
     auto p = periodicity_->compute( i + imin_, j + jmin_ );
     return index( p.i - imin_, p.j - jmin_ );
+}
+
+orca::PointIJ Orca::periodicIJ( idx_t i, idx_t j ) const {
+    return periodicity_->compute( i + imin_, j + jmin_ );
 }
 
 Orca::Orca( const Config& config ) :

--- a/src/atlas-orca/grid/Orca.h
+++ b/src/atlas-orca/grid/Orca.h
@@ -18,6 +18,7 @@
 #include "atlas/runtime/Exception.h"
 #include "atlas/util/Config.h"
 #include "atlas/util/Point.h"
+#include "atlas-orca/util/PointIJ.h"
 
 namespace atlas {
 class Mesh;
@@ -165,7 +166,6 @@ public:  // methods
     /// Constructor taking a name/uid and a configuration (spec)
     Orca( const std::string& name_or_uid, const Config& );
 
-public:
     idx_t size() const override;
 
     Spec spec() const override;
@@ -196,6 +196,7 @@ public:
     bool invalidElement( idx_t i, idx_t j ) const { return invalid_element_[( imin_ + i ) + ( jmin_ + j ) * jstride_]; }
 
     gidx_t periodicIndex( idx_t i, idx_t j ) const;
+    atlas::orca::PointIJ periodicIJ( idx_t i, idx_t j ) const;
 
     void index2ij( gidx_t gidx, idx_t& i, idx_t& j ) const {
         //gidx = jstride_ * (jmin_+j) + (imin_+i);

--- a/src/atlas-orca/grid/OrcaGrid.h
+++ b/src/atlas-orca/grid/OrcaGrid.h
@@ -14,6 +14,7 @@
 
 #include "Orca.h"
 #include "atlas/grid/Grid.h"
+#include "atlas-orca/util/PointIJ.h"
 
 
 namespace atlas {
@@ -53,6 +54,7 @@ public:
     int haloSouth() const { return grid_->haloSouth(); }
 
     gidx_t periodicIndex( idx_t i, idx_t j ) const { return grid_->periodicIndex( i, j ); }
+    orca::PointIJ periodicIJ( idx_t i, idx_t j ) const { return grid_->periodicIJ( i, j ); }
 
     void index2ij( gidx_t gidx, idx_t& i, idx_t& j ) const { grid_->index2ij( gidx, i, j ); }
 

--- a/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
+++ b/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
@@ -240,7 +240,7 @@ PointXY LocalOrcaGrid::normalised_grid_xy( idx_t ix, idx_t iy ) const {
       west = lon00_ - 20.;
   }
 
-  if ( ij.i < nx_orca_ / 2 ) {
+  if ( ix + ix_orca_min_ < orca_.nx() / 2 ) {
     auto lon_first_half_normaliser  = util::NormaliseLongitude{west};
     return PointXY( lon_first_half_normaliser( xy.x() ), xy.y() );
   } else {

--- a/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
+++ b/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
@@ -323,13 +323,13 @@ PointIJ LocalOrcaGrid::orca_haloed_global_grid_ij( idx_t ix, idx_t iy ) const {
     //ij = orca_.periodicIJ(ij.i, ij.j);
   }
 
-  ATLAS_ASSERT_MSG( ij.i > ix_glb_min,
+  ATLAS_ASSERT_MSG( ij.i >= ix_glb_min,
                     std::to_string(ij.i) + std::string(" < ") + std::to_string(ix_glb_min) );
-  ATLAS_ASSERT_MSG( ij.j > iy_glb_min,
+  ATLAS_ASSERT_MSG( ij.j >= iy_glb_min,
                     std::to_string(ij.j) + std::string(" < ") + std::to_string(iy_glb_min) );
-  ATLAS_ASSERT_MSG( ij.i < ix_glb_min + nx_orca_glb,
+  ATLAS_ASSERT_MSG( ij.i <= ix_glb_min + nx_orca_glb,
                     std::to_string(ij.i) + std::string(" > ") + std::to_string(ix_glb_min + nx_orca_glb) );
-  ATLAS_ASSERT_MSG( ij.j < iy_glb_min + ny_orca_glb,
+  ATLAS_ASSERT_MSG( ij.j <= iy_glb_min + ny_orca_glb,
                     std::to_string(ij.j) + std::string(" > ") + std::to_string(iy_glb_min + ny_orca_glb) );
   return ij;
 }
@@ -406,7 +406,6 @@ bool LocalOrcaGrid::water( idx_t ix, idx_t iy ) const {
 
   const auto ij_glb = this->orca_haloed_global_grid_ij( ix, iy );
 
-  const auto ij_glb = this->global_ij( ix, iy );
   if ( (ij_glb.i > orca_.nx() + orca_.haloWest()) ||
        (ij_glb.j > orca_.ny() + orca_.haloNorth()) ||
        (ij_glb.i < - orca_.haloEast()) ||

--- a/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
+++ b/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2021- ECMWF.
+ * (C) Crown Copyright 2024 Met Office
  *
  * This software is licensed under the terms of the Apache Licence Version 2.0
  * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
@@ -176,9 +176,9 @@ LocalOrcaGrid::LocalOrcaGrid(const OrcaGrid& grid, const SurroundingRectangle& r
         const auto ij_glb_haloed = this->orca_haloed_global_grid_ij( ix, iy );
         // The southern boundary does not contain halo points apart from at the
         // east and west limits.
-        if ( this->orca_halo( ix, iy ) && 
-             ((ij_glb_haloed.j >= 0) || 
-              (ij_glb_haloed.i < 0) || 
+        if ( this->orca_halo( ix, iy ) &&
+             ((ij_glb_haloed.j >= 0) ||
+              (ij_glb_haloed.i < 0) ||
               (ij_glb_haloed.i >= orca_.nx())) ) {
         // this one should wrap when we have a standard halo, but still
         // preserve the orca halo as though points in the orca are real points
@@ -309,7 +309,7 @@ PointIJ LocalOrcaGrid::orca_haloed_global_grid_ij( idx_t ix, idx_t iy ) const {
 
   ATLAS_ASSERT_MSG( ij.j >= -orca_.haloSouth(),
                     std::string("Cannot extend below the southern ORCA halo: j = ") +
-                    std::to_string(ij.j) + std::string(", orca_.haloSouth() = ") + 
+                    std::to_string(ij.j) + std::string(", orca_.haloSouth() = ") +
                     std::to_string(orca_.haloSouth()) );
 
   // wrap points outside of orca_grid halo back into the orca grid.

--- a/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
+++ b/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
@@ -1,0 +1,392 @@
+/*
+ * (C) Copyright 2021- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include <limits>
+
+#include "atlas/util/Topology.h"
+#include "atlas-orca/meshgenerator/LocalOrcaGrid.h"
+
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+namespace eckit {
+class Parametrisation;
+}
+#endif
+
+namespace atlas::orca::meshgenerator {
+
+//----------------------------------------------------------------------------------------------------------------------
+LocalOrcaGrid::LocalOrcaGrid(const OrcaGrid& grid, const SurroundingRectangle& rectangle) :
+        orca_(grid) {
+
+  ix_orca_min_ = rectangle.ix_min();
+  ix_orca_max_ = rectangle.ix_max();
+  iy_orca_min_ = rectangle.iy_min();
+  iy_orca_max_ = rectangle.iy_max();
+
+//  std::cout << " rectangle.nx() " << rectangle.nx()
+//            << " rectangle.ny() " << rectangle.ny()
+//            << " rectangle.ix_min() " << rectangle.ix_min()
+//            << " rectangle.ix_max() " << rectangle.ix_max()
+//            << " rectangle.iy_min() " << rectangle.iy_min()
+//            << " rectangle.iy_max() " << rectangle.iy_max() << std::endl;
+
+  // Ensure we include the orca halo points if we are at the edge of the orca grid.
+  if (rectangle.ix_min() <= 0) {
+    ix_orca_min_ += -orca_.haloWest();
+  }
+  if (rectangle.ix_max() >= orca_.nx()) {
+    ix_orca_max_ += orca_.haloEast() - 1;
+  }
+  // no halo at the Southern boundary of orca grid (closed boundary we think?)
+  if (rectangle.iy_min() <= 0) {
+    iy_orca_min_ = -orca_.haloSouth();
+  }
+  if (rectangle.iy_max() >= orca_.ny()) {
+    iy_orca_max_ += orca_.haloNorth() - 1;
+  }
+
+  std::cout << " orca_.nx() " << orca_.nx()
+            << " orca_.ny() " << orca_.ny() << std::endl;
+
+  std::cout << " ix_orca_min_ " <<  ix_orca_min_
+            << " ix_orca_max_ " <<  ix_orca_max_
+            << " iy_orca_min_ " <<  iy_orca_min_
+            << " iy_orca_max_ " <<  iy_orca_max_ << std::endl;
+
+  // dimensions of the rectangle including the ORCA halo points
+  // NOTE: +1 because the size of the dimension is one bigger than index of the last element
+  nx_orca_ = ix_orca_max_ - ix_orca_min_ + 1;
+  ny_orca_ = iy_orca_max_ - iy_orca_min_ + 1;
+  size_ = nx_orca_ * ny_orca_;
+  std::cout << "nx_orca_ " << nx_orca_ << " ny_orca_ " << ny_orca_ << " size_ " << size_ << std::endl;
+
+  // partitions and local indices in surrounding rectangle
+  parts.resize( size_, -1 );
+  halo.resize( size_, 0 );
+  is_node.resize( size_, false );
+  is_ghost.resize( size_, 1 );
+  nb_used_real_nodes_ = 0;
+  nb_used_ghost_nodes_ = 0;
+  uint16_t nb_used_halo_nodes = 0;
+  {
+    //atlas_omp_parallel_for( idx_t iy = 0; iy < ny_; iy++ )
+    for( size_t iy = 0; iy < ny_orca_; iy++ ) {
+      for ( size_t ix = 0; ix < nx_orca_; ix++ ) {
+        idx_t ii = index( ix, iy );
+        const auto ij_glb_haloed = this->global_ij( ix, iy );
+        idx_t ix_reg = ij_glb_haloed.i;
+        idx_t iy_reg = ij_glb_haloed.j;
+        if (ix_reg < rectangle.ix_min()) {
+          ix_reg = rectangle.ix_min();
+        } else if (ix_reg > rectangle.ix_max()) {
+          ix_reg = rectangle.ix_max();
+        }
+        if (iy_reg < rectangle.iy_min()) {
+          iy_reg = rectangle.iy_min();
+        } else if (iy_reg >= rectangle.iy_max()) {
+          iy_reg = rectangle.iy_max();
+        }
+        ix_reg -= rectangle.ix_min();
+        iy_reg -= rectangle.iy_min();
+        idx_t reg_ii = rectangle.index(ix_reg, iy_reg);
+        ASSERT(reg_ii < rectangle.parts.size());
+        ASSERT(reg_ii < rectangle.halo.size());
+        ASSERT(reg_ii < rectangle.is_ghost.size());
+        parts.at( ii ) = rectangle.parts.at( reg_ii );
+        halo.at( ii ) = rectangle.halo.at( reg_ii );
+        //const auto ij_glb = this->orca_haloed_global_grid_ij( ix, iy );
+        is_ghost.at( ii ) = rectangle.is_ghost.at( reg_ii );
+      }
+    }
+  }
+  std::cout << "determine number of cells and number of nodes"<< std::endl;
+
+  // determine number of cells and number of nodes
+  {
+    std::vector<int> is_cell(size_, false);
+    auto mark_node_used = [&]( int ix, int iy ) {
+      idx_t ii = index( ix, iy );
+      if ( !is_node.at(ii) ) {
+        ++nb_used_nodes_;
+        is_node.at(ii) = true;
+        if ( is_ghost.at( ii ) ) {
+          ++nb_used_ghost_nodes_;
+          if ( halo[ii] != 0)
+            ++nb_used_halo_nodes;
+        } else {
+          ++nb_used_real_nodes_;
+        }
+      }
+    };
+    auto mark_cell_used = [&]( int ix, int iy ) {
+      idx_t ii = index( ix, iy );
+      if ( !is_cell.at(ii) ) {
+        ++nb_cells_;
+        is_cell.at(ii) = true;
+      }
+    };
+    // Loop over all elements to determine which are required
+    nb_cells_ = 0;
+    nb_used_nodes_ = 0;
+    for ( idx_t iy = 0; iy < ny_orca_-1; iy++ ) {
+      for ( idx_t ix = 0; ix < nx_orca_-1; ix++ ) {
+        if ( ! is_ghost[index( ix, iy )]) {
+          mark_cell_used( ix, iy );
+          mark_node_used( ix, iy );
+          mark_node_used( ix + 1, iy );
+          mark_node_used( ix + 1, iy + 1 );
+          mark_node_used( ix, iy + 1 );
+        } // if not ghost index
+      }
+    }
+  }
+
+  // adjust ghost points based on orca halo ghost info
+  is_ghost_including_orca_halo.resize( size_, 1 );
+  for( size_t iy = 0; iy < ny_orca_; iy++ ) {
+    for ( size_t ix = 0; ix < nx_orca_; ix++ ) {
+      idx_t ii = index( ix, iy );
+      if ( is_node.at( ii ) ) {
+        is_ghost_including_orca_halo.at( ii ) = static_cast<bool>(is_ghost.at( ii ));
+        // this one should wrap when we have a standard halo, but still
+        // preserve the orca halo as though points in the orca are real points
+        // for the purposes of the wrapping. But it isn't working quite right
+        const auto ij_glb_haloed = this->orca_haloed_global_grid_ij( ix, iy );
+        //const auto ij_glb_haloed = this->global_ij( ix, iy );
+        // The southern boundary does not contain halo points apart from at the
+        // east and west limits.
+        if ( (ij_glb_haloed.j >= 0) || (ij_glb_haloed.i < 0) || (ij_glb_haloed.i >= orca_.nx()) ) {
+          if ( (ij_glb_haloed.i > orca_.nx() + orca_.haloWest()) ||
+               (ij_glb_haloed.j > orca_.ny() + orca_.haloNorth()) ||
+               (ij_glb_haloed.i < - orca_.haloEast()) ||
+               (ij_glb_haloed.j < - orca_.haloSouth()) ) {
+              std::cout << ij_glb_haloed << " out of bounds." << std::endl;
+              ASSERT(false);
+          }
+
+          is_ghost_including_orca_halo.at( ii ) = static_cast<bool>(is_ghost.at( ii )) || orca_.ghost( ij_glb_haloed.i, ij_glb_haloed.j );
+        }
+      }
+    }
+  }
+
+  // setup normalisation objects
+  {
+    lon00_ = orca_.xy( 0, 0 ).x();
+    lon00_normaliser_ = util::NormaliseLongitude(lon00_ - 180. );
+  }
+}
+int LocalOrcaGrid::index( idx_t ix, idx_t iy ) const {
+  ATLAS_ASSERT_MSG(static_cast<size_t>(ix) < nx_orca_,
+     std::string("ix >= nx_orca_: ") + std::to_string(ix) + " >= " + std::to_string(nx_orca_));
+  ATLAS_ASSERT_MSG(static_cast<size_t>(iy) < ny_orca_,
+    std::string("iy >= ny_orca_: ") + std::to_string(iy) + " >= " + std::to_string(ny_orca_));
+  return iy * nx_orca_ + ix;
+}
+
+PointIJ LocalOrcaGrid::global_ij( idx_t ix, idx_t iy ) const {
+  return PointIJ(ix_orca_min_ + ix, iy_orca_min_ + iy);
+}
+
+const PointXY LocalOrcaGrid::grid_xy( idx_t ix, idx_t iy ) const {
+  const auto ij = this->master_global_ij( ix, iy );
+  return orca_.xy( ij.i, ij.j );
+}
+
+PointXY LocalOrcaGrid::normalised_grid_xy( idx_t ix, idx_t iy ) const {
+  double west  = lon00_ - 90.;
+  const auto ij = this->master_global_ij( ix, iy );
+  if ( (ij.i > orca_.nx() + orca_.haloWest()) ||
+       (ij.j > orca_.ny() + orca_.haloNorth()) ||
+       (ij.i < - orca_.haloEast()) ||
+       (ij.j < - orca_.haloSouth()) ) {
+      std::cout << ij << " out of bounds when calling normalised_grid_xy." << std::endl;
+      ASSERT(false);
+  }
+  const PointXY xy = orca_.xy( ij.i, ij.j );
+  double lon1 = lon00_normaliser_( orca_.xy( 1, ij.j ).x() );
+  if ( lon1 < lon00_ - 10. ) {
+      west = lon00_ - 20.;
+  }
+
+  if ( ij.i < nx_orca_ / 2 ) {
+    auto lon_first_half_normaliser  = util::NormaliseLongitude{west};
+    return PointXY( lon_first_half_normaliser( xy.x() ), xy.y() );
+  } else {
+    auto lon_second_half_normaliser = util::NormaliseLongitude{lon00_ + 90.};
+    return PointXY( lon_second_half_normaliser( xy.x() ), xy.y() );
+  }
+}
+
+// unique global index of the orca grid excluding orca grid halos (orca halo points are wrapped to their master index).
+// Note: right now need to add +1 to this to fill the field with corresponding name.
+gidx_t LocalOrcaGrid::master_global_index( idx_t ix, idx_t iy ) const {
+  //const auto ij = this->orca_haloed_global_grid_ij( ix, iy );
+  const auto ij = this->global_ij( ix, iy );
+  return orca_.periodicIndex( ij.i, ij.j );
+}
+
+PointIJ LocalOrcaGrid::master_global_ij( idx_t ix, idx_t iy ) const {
+  //const auto ij = this->global_ij( ix, iy );
+  //return orca_.periodicIJ( ij.i, ij.j );
+  const auto master_idx = this->master_global_index( ix, iy );
+  idx_t ix_glb_master, iy_glb_master;
+  orca_.index2ij( master_idx, ix_glb_master, iy_glb_master );
+  return PointIJ(ix_glb_master, iy_glb_master);
+}
+
+PointLonLat LocalOrcaGrid::normalised_grid_master_lonlat( idx_t ix, idx_t iy ) const {
+  double west  = lon00_ - 90.;
+  const auto ij = this->global_ij( ix, iy );
+  if ( (ij.i > orca_.nx() + orca_.haloWest()) ||
+       (ij.j > orca_.ny() + orca_.haloNorth()) ||
+       (ij.i < - orca_.haloEast()) ||
+       (ij.j < - orca_.haloSouth()) ) {
+      std::cout << ij << " out of bounds when calling normalised_grid_master_lonlat." << std::endl;
+      ASSERT(false);
+  }
+  //const auto ij = this->orca_haloed_global_grid_ij( ix, iy );
+  const auto master_ij = this->master_global_ij( ix, iy );
+
+  const PointLonLat lonlat = orca_.lonlat( master_ij.i, master_ij.j );
+
+  double lon1 = lon00_normaliser_( orca_.xy( 1, ij.j ).x() );
+  if ( lon1 < lon00_ - 10. ) {
+      west = lon00_ - 20.;
+  }
+
+  if ( ij.i < nx_orca_ / 2 ) {
+    auto lon_first_half_normaliser  = util::NormaliseLongitude{west};
+    return PointLonLat( lon_first_half_normaliser( lonlat.lon() ), lonlat.lat() );
+  } else {
+    auto lon_second_half_normaliser = util::NormaliseLongitude{lon00_ + 90.};
+    return PointLonLat( lon_second_half_normaliser( lonlat.lon() ), lonlat.lat() );
+  }
+}
+
+// unique global index of the orca grid including orca grid halos.  This needs
+// to wrap points back into the orca grid, but is subtly different from
+// OrcaGrid.PeriodicIndex as it will only wrap points that are outside of the
+// orca grid halos
+PointIJ LocalOrcaGrid::orca_haloed_global_grid_ij( idx_t ix, idx_t iy ) const {
+  // global grid properties
+  const auto iy_glb_min = -orca_.haloSouth();
+  const auto ix_glb_min = -orca_.haloWest();
+  const auto nx_orca_glb = orca_.nx() + orca_.haloEast() + orca_.haloWest();
+  const auto ny_orca_glb = orca_.ny() + orca_.haloSouth() + orca_.haloNorth();
+  const idx_t glbarray_offset  = -( nx_orca_glb * iy_glb_min ) - ix_glb_min;
+  const idx_t glbarray_jstride = nx_orca_glb;
+
+  auto ij = this->global_ij( ix, iy );
+
+  // wrap points outside of orca_grid halo back into the orca grid.
+  if ( (ij.i > ix_glb_min + nx_orca_glb) || (ij.j > iy_glb_min + ny_orca_glb)
+    || (ij.i < ix_glb_min) || (ij.j < iy_glb_min) ) {
+    std::cout << "ij.i, ij.j "  << ij.i << ", " << ij.j << std::endl;
+    //gidx_t p_idx = orca_.periodicIndex(ij.i, ij.j);
+    //idx_t i, j;
+    //orca_.index2ij(p_idx, i, j);
+    //ij.i = i;
+    //ij.j = j;
+    ij = orca_.periodicIJ(ij.i, ij.j);
+    std::cout << "adjusted i, j "  << ij.i << ", " << ij.j << std::endl;
+  }
+
+  ATLAS_ASSERT_MSG( ij.i >= ix_glb_min,
+                    std::to_string(ij.i) + std::string(" < ") + std::to_string(ix_glb_min) );
+  ATLAS_ASSERT_MSG( ij.j >= iy_glb_min,
+                    std::to_string(ij.j) + std::string(" < ") + std::to_string(iy_glb_min) );
+  ATLAS_ASSERT_MSG( ij.i <= ix_glb_min + nx_orca_glb,
+                    std::to_string(ij.i) + std::string(" > ") + std::to_string(ix_glb_min + nx_orca_glb) );
+  ATLAS_ASSERT_MSG( ij.j <= iy_glb_min + ny_orca_glb,
+                    std::to_string(ij.j) + std::string(" > ") + std::to_string(iy_glb_min + ny_orca_glb) );
+  return ij;
+}
+
+idx_t LocalOrcaGrid::orca_haloed_global_grid_index( idx_t ix, idx_t iy ) const {
+  PointIJ ij = this->orca_haloed_global_grid_ij( ix, iy );
+  const auto iy_glb_min = -orca_.haloSouth();
+  const auto ix_glb_min = -orca_.haloWest();
+  const auto nx_orca_glb = orca_.nx() + orca_.haloEast() + orca_.haloWest();
+  const auto ny_orca_glb = orca_.ny() + orca_.haloSouth() + orca_.haloNorth();
+  const idx_t glbarray_offset  = -( nx_orca_glb * iy_glb_min ) - ix_glb_min;
+  const idx_t glbarray_jstride = nx_orca_glb;
+  return glbarray_offset + ij.j * glbarray_jstride + ij.i;
+}
+
+void LocalOrcaGrid::flags( idx_t ix, idx_t iy, util::detail::BitflagsView<int>& flag_view ) const {
+  flag_view.reset();
+  const auto ij_glb = this->global_ij( ix, iy );
+  //const auto ij_glb = this->orca_haloed_global_grid_ij( ix, iy );
+  if ( (ij_glb.i > orca_.nx() + orca_.haloWest()) ||
+       (ij_glb.j > orca_.ny() + orca_.haloNorth()) ||
+       (ij_glb.i < - orca_.haloEast()) ||
+       (ij_glb.j < - orca_.haloSouth()) ) {
+      std::cout << ij_glb << " out of bounds when calling orca_.flags." << std::endl;
+      ASSERT(false);
+  }
+  if ( this->is_ghost[this->index(ix, iy)] ) {
+    flag_view.set( util::Topology::GHOST );
+    if( this->orca_haloed_global_grid_index( ix, iy ) !=
+        this->master_global_index( ix, iy ) ) {
+      const auto normalised_xy = this->normalised_grid_xy( ix, iy );
+      if ( ij_glb.i >= orca_.nx() - orca_.haloWest() ) {
+        flag_view.set( util::Topology::PERIODIC );
+      }
+      else if ( ij_glb.i < orca_.haloEast() - 1 ) {
+        flag_view.set( util::Topology::PERIODIC );
+      }
+      if ( ij_glb.j >= orca_.ny() - orca_.haloNorth() - 1 ) {
+          flag_view.set( util::Topology::PERIODIC );
+          if ( normalised_xy.x() > lon00_ + 90. ) {
+              flag_view.set( util::Topology::EAST );
+          }
+          else {
+              flag_view.set( util::Topology::WEST );
+          }
+      }
+
+      if ( flag_view.check( util::Topology::PERIODIC ) ) {
+        // It can still happen that nodes were flagged as periodic wrongly
+        // e.g. where the grid folds into itself
+        auto lonlat_master = this->normalised_grid_master_lonlat(ix, iy);
+        if( std::abs(lonlat_master.lon() - normalised_xy.x()) < 1.e-12 ) {
+            flag_view.unset( util::Topology::PERIODIC );
+            // if (( std::abs(lonlat_master.lat() - normalised_xy.y()) < 1.e-12 ) &&
+            //     ( ij_glb.j >= orca_.ny() - orca_.haloNorth() - 1 ))
+            //     grid_fold_inodes.push_back(inode);
+        }
+      }
+    }
+  }
+
+  flag_view.set( orca_.land( ij_glb.i, ij_glb.j ) ? util::Topology::LAND : util::Topology::WATER );
+
+  if ( ij_glb.i <= 0 ) {
+    flag_view.set( util::Topology::BC | util::Topology::WEST );
+  }
+  else if ( ij_glb.j >= orca_.nx() ) {
+    flag_view.set( util::Topology::BC | util::Topology::EAST );
+  }
+}
+bool LocalOrcaGrid::water( idx_t ix, idx_t iy ) const {
+  //const auto ij_glb = this->orca_haloed_global_grid_ij( ix, iy );
+  const auto ij_glb = this->global_ij( ix, iy );
+  if ( (ij_glb.i > orca_.nx() + orca_.haloWest()) ||
+       (ij_glb.j > orca_.ny() + orca_.haloNorth()) ||
+       (ij_glb.i < - orca_.haloEast()) ||
+       (ij_glb.j < - orca_.haloSouth()) ) {
+      std::cout << ij_glb << " out of bounds when calling orca_.water." << std::endl;
+      ASSERT(false);
+  }
+  return orca_.water( ij_glb.i, ij_glb.j );
+}
+}  // namespace atlas::orca::meshgenerator

--- a/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
+++ b/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
@@ -47,20 +47,20 @@ LocalOrcaGrid::LocalOrcaGrid(const OrcaGrid& grid, const SurroundingRectangle& r
     iy_orca_max_ = std::max(rectangle.iy_max(), orca_.ny() + orca_.haloNorth() - 1);
   }
 
-  std::cout << " orca_.nx() " << orca_.nx()
-            << " orca_.ny() " << orca_.ny() << std::endl;
+  // std::cout << " orca_.nx() " << orca_.nx()
+  //           << " orca_.ny() " << orca_.ny() << std::endl;
 
-  std::cout << " ix_orca_min_ " <<  ix_orca_min_
-            << " ix_orca_max_ " <<  ix_orca_max_
-            << " iy_orca_min_ " <<  iy_orca_min_
-            << " iy_orca_max_ " <<  iy_orca_max_ << std::endl;
+  // std::cout << " ix_orca_min_ " <<  ix_orca_min_
+  //           << " ix_orca_max_ " <<  ix_orca_max_
+  //           << " iy_orca_min_ " <<  iy_orca_min_
+  //           << " iy_orca_max_ " <<  iy_orca_max_ << std::endl;
 
   // NOTE: +1 because the size of the dimension is one bigger than index of the last element
   nx_orca_ = ix_orca_max_ - ix_orca_min_ + 1;
   ny_orca_ = iy_orca_max_ - iy_orca_min_ + 1;
   size_ = nx_orca_ * ny_orca_;
 
-  std::cout << "nx_orca_ " << nx_orca_ << " ny_orca_ " << ny_orca_ << " size_ " << size_ << std::endl;
+  // std::cout << "nx_orca_ " << nx_orca_ << " ny_orca_ " << ny_orca_ << " size_ " << size_ << std::endl;
 
 
   // Partitions and local indices in surrounding rectangle
@@ -123,7 +123,7 @@ LocalOrcaGrid::LocalOrcaGrid(const OrcaGrid& grid, const SurroundingRectangle& r
       }
     }
   }
-  std::cout << "determine number of cells and number of nodes"<< std::endl;
+  // std::cout << "determine number of cells and number of nodes"<< std::endl;
 
   // determine number of cells and number of nodes
   {

--- a/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
+++ b/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
@@ -43,7 +43,6 @@ LocalOrcaGrid::LocalOrcaGrid(const OrcaGrid& grid, const SurroundingRectangle& r
   if (rectangle.iy_min() <= 0) {
     iy_orca_min_ = -orca_.haloSouth();
   }
-
   if (rectangle.iy_max() >= orca_.ny() - 1) {
     iy_orca_max_ = std::max(rectangle.iy_max(), orca_.ny() + orca_.haloNorth() - 1);
   }
@@ -119,7 +118,7 @@ LocalOrcaGrid::LocalOrcaGrid(const OrcaGrid& grid, const SurroundingRectangle& r
         // If this is a periodic point, then it is always a ghost point.
         const auto ij_wrapped = this->orca_haloed_global_grid_ij( ix, iy );
         if ( (ij_wrapped.i != ij_glb_haloed.i) || (ij_wrapped.j != ij_glb_haloed.j) ) {
-          is_ghost.at(ii) = 1;
+          is_ghost.at( ii ) = 1;
         }
       }
     }
@@ -159,14 +158,11 @@ LocalOrcaGrid::LocalOrcaGrid(const OrcaGrid& grid, const SurroundingRectangle& r
     nb_used_nodes_ = 0;
     for ( idx_t iy = 0; iy < ny_orca_-1; iy++ ) {
       for ( idx_t ix = 0; ix < nx_orca_-1; ix++ ) {
-        idx_t ii = index( ix, iy );
-        if ( halo[ii] <= rectangle.halosize() ) {
-          mark_cell_used( ix, iy );
-          mark_node_used( ix, iy );
-          mark_node_used( ix + 1, iy );
-          mark_node_used( ix + 1, iy + 1 );
-          mark_node_used( ix, iy + 1 );
-        }
+        mark_cell_used( ix, iy );
+        mark_node_used( ix, iy );
+        mark_node_used( ix + 1, iy );
+        mark_node_used( ix + 1, iy + 1 );
+        mark_node_used( ix, iy + 1 );
       }
     }
   }

--- a/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
+++ b/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
@@ -73,7 +73,7 @@ LocalOrcaGrid::LocalOrcaGrid(const OrcaGrid& grid, const SurroundingRectangle& r
   nb_used_ghost_nodes_ = 0;
   nb_used_real_cells_ = 0;
   nb_used_ghost_cells_ = 0;
-  uint16_t nb_used_halo_nodes = 0;
+  int16_t nb_used_halo_nodes = 0;
   {
     //atlas_omp_parallel_for( idx_t iy = 0; iy < ny_; iy++ )
     for( size_t iy = 0; iy < ny_orca_; iy++ ) {

--- a/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
+++ b/src/atlas-orca/meshgenerator/LocalOrcaGrid.cc
@@ -257,8 +257,6 @@ gidx_t LocalOrcaGrid::master_global_index( idx_t ix, idx_t iy ) const {
 }
 
 PointIJ LocalOrcaGrid::master_global_ij( idx_t ix, idx_t iy ) const {
-  //const auto ij = this->global_ij( ix, iy );
-  //return orca_.periodicIJ( ij.i, ij.j );
   const auto master_idx = this->master_global_index( ix, iy );
   idx_t ix_glb_master, iy_glb_master;
   orca_.index2ij( master_idx, ix_glb_master, iy_glb_master );
@@ -275,7 +273,6 @@ PointLonLat LocalOrcaGrid::normalised_grid_master_lonlat( idx_t ix, idx_t iy ) c
       std::cout << ij << " out of bounds when calling normalised_grid_master_lonlat." << std::endl;
       ASSERT(false);
   }
-  //const auto ij = this->orca_haloed_global_grid_ij( ix, iy );
   const auto master_ij = this->master_global_ij( ix, iy );
 
   const PointLonLat lonlat = orca_.lonlat( master_ij.i, master_ij.j );
@@ -387,9 +384,6 @@ void LocalOrcaGrid::flags( idx_t ix, idx_t iy, util::detail::BitflagsView<int>& 
         auto lonlat_master = this->normalised_grid_master_lonlat(ix, iy);
         if( std::abs(lonlat_master.lon() - normalised_xy.x()) < 1.e-12 ) {
             flag_view.unset( util::Topology::PERIODIC );
-            // if (( std::abs(lonlat_master.lat() - normalised_xy.y()) < 1.e-12 ) &&
-            //     ( ij_glb.j >= orca_.ny() - orca_.haloNorth() - 1 ))
-            //     grid_fold_inodes.push_back(inode);
         }
       }
     }

--- a/src/atlas-orca/meshgenerator/LocalOrcaGrid.h
+++ b/src/atlas-orca/meshgenerator/LocalOrcaGrid.h
@@ -72,7 +72,7 @@ class LocalOrcaGrid {
     idx_t orca_haloed_global_grid_index( idx_t ix, idx_t iy ) const;
     void flags( idx_t ix, idx_t iy, util::detail::BitflagsView<int>& flag_view ) const;
     bool water( idx_t ix, idx_t iy ) const;
-    bool orca_halo( idx_t ix, idx_t iy ) const;
+    bool orca_edge( idx_t ix, idx_t iy ) const;
 
  private:
     const OrcaGrid orca_;

--- a/src/atlas-orca/meshgenerator/LocalOrcaGrid.h
+++ b/src/atlas-orca/meshgenerator/LocalOrcaGrid.h
@@ -40,25 +40,25 @@ class LocalOrcaGrid {
     std::vector<int> is_ghost;
     std::vector<int> is_node;
     std::vector<int> is_cell;
-    uint64_t size() const {return size_;}
+    int64_t size() const {return size_;}
     int ix_min() const {return ix_orca_min_;}
     int ix_max() const {return ix_orca_max_;}
     int iy_min() const {return iy_orca_min_;}
     int iy_max() const {return iy_orca_max_;}
-    uint64_t nx() const {return nx_orca_;}
-    uint64_t ny() const {return ny_orca_;}
+    int64_t nx() const {return nx_orca_;}
+    int64_t ny() const {return ny_orca_;}
     // number of real nodes on this partition
-    uint64_t nb_used_real_nodes() const {return nb_used_real_nodes_;}
+    int64_t nb_used_real_nodes() const {return nb_used_real_nodes_;}
     // number of ghost nodes on this partition
-    uint64_t nb_used_ghost_nodes() const {return nb_used_ghost_nodes_;}
+    int64_t nb_used_ghost_nodes() const {return nb_used_ghost_nodes_;}
     // number of nodes used by cells on this partition
-    uint64_t nb_used_nodes() const {return nb_used_nodes_;}
+    int64_t nb_used_nodes() const {return nb_used_nodes_;}
     // number of cells on this partition
-    uint64_t nb_cells() const {return nb_cells_;}
+    int64_t nb_cells() const {return nb_cells_;}
     // number of ghost cells on this partition
-    uint64_t nb_used_ghost_cells() const {return nb_used_ghost_cells_;}
+    int64_t nb_used_ghost_cells() const {return nb_used_ghost_cells_;}
     // number of real cells on this paritition
-    uint64_t nb_used_real_cells() const {return nb_used_real_cells_;}
+    int64_t nb_used_real_cells() const {return nb_used_real_cells_;}
 
     int index( idx_t ix, idx_t iy ) const;
     LocalOrcaGrid( const OrcaGrid& grid, const SurroundingRectangle& rectangle );
@@ -76,19 +76,19 @@ class LocalOrcaGrid {
 
  private:
     const OrcaGrid orca_;
-    uint64_t size_;
+    int64_t size_;
     int ix_orca_min_;
     int ix_orca_max_;
     int iy_orca_min_;
     int iy_orca_max_;
-    uint64_t nx_orca_;
-    uint64_t ny_orca_;
-    uint64_t nb_used_nodes_;
-    uint64_t nb_used_real_nodes_;
-    uint64_t nb_used_ghost_nodes_;
-    uint64_t nb_cells_;
-    uint64_t nb_used_ghost_cells_;
-    uint64_t nb_used_real_cells_;
+    int64_t nx_orca_;
+    int64_t ny_orca_;
+    int64_t nb_used_nodes_;
+    int64_t nb_used_real_nodes_;
+    int64_t nb_used_ghost_nodes_;
+    int64_t nb_cells_;
+    int64_t nb_used_ghost_cells_;
+    int64_t nb_used_real_cells_;
     double lon00_;
     util::NormaliseLongitude lon00_normaliser_;
 };

--- a/src/atlas-orca/meshgenerator/LocalOrcaGrid.h
+++ b/src/atlas-orca/meshgenerator/LocalOrcaGrid.h
@@ -1,0 +1,87 @@
+/*
+ * (C) Copyright 2021- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#pragma once
+
+#include <limits>
+#include <memory>
+
+#include "atlas/meshgenerator/MeshGenerator.h"
+#include "atlas/util/Config.h"
+#include "atlas/grid/Distribution.h"
+#include "atlas/util/Point.h"
+#include "atlas/util/Bitflags.h"
+#include "atlas-orca/grid/OrcaGrid.h"
+#include "atlas-orca/meshgenerator/SurroundingRectangle.h"
+#include "atlas-orca/util/PointIJ.h"
+
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+namespace eckit {
+class Parametrisation;
+}
+#endif
+
+namespace atlas::orca::meshgenerator {
+
+//----------------------------------------------------------------------------------------------------------------------
+class LocalOrcaGrid {
+ public:
+    std::vector<int> parts;
+    std::vector<int> halo;
+    std::vector<int> is_ghost_including_orca_halo;
+    std::vector<int> is_ghost;
+    std::vector<int> is_node;
+    uint64_t size() const {return size_;}
+    int ix_min() const {return ix_orca_min_;}
+    int ix_max() const {return ix_orca_max_;}
+    int iy_min() const {return iy_orca_min_;}
+    int iy_max() const {return iy_orca_max_;}
+    uint64_t nx() const {return nx_orca_;}
+    uint64_t ny() const {return ny_orca_;}
+    // number of real nodes on this partition
+    uint64_t nb_used_real_nodes() const {return nb_used_real_nodes_;}
+    // number of ghost nodes on this partition
+    uint64_t nb_used_ghost_nodes() const {return nb_used_ghost_nodes_;}
+    // number of nodes used by cells on this partition
+    uint64_t nb_used_nodes() const {return nb_used_nodes_;}
+    // number of cells on this partition
+    uint64_t nb_cells() const {return nb_cells_;}
+
+    int index( idx_t ix, idx_t iy ) const;
+    LocalOrcaGrid( const OrcaGrid& grid, const SurroundingRectangle& rectangle );
+    PointIJ global_ij( idx_t ix, idx_t iy ) const;
+    const PointXY grid_xy( idx_t ix, idx_t iy ) const;
+    PointXY normalised_grid_xy( idx_t ix, idx_t iy ) const;
+    PointIJ master_global_ij( idx_t ix, idx_t iy ) const;
+    gidx_t master_global_index( idx_t ix, idx_t iy ) const;
+    PointLonLat normalised_grid_master_lonlat( idx_t ix, idx_t iy ) const;
+    PointIJ orca_haloed_global_grid_ij( idx_t ix, idx_t iy ) const;
+    idx_t orca_haloed_global_grid_index( idx_t ix, idx_t iy ) const;
+    void flags( idx_t ix, idx_t iy, util::detail::BitflagsView<int>& flag_view ) const;
+    bool water( idx_t ix, idx_t iy ) const;
+
+ private:
+    const OrcaGrid orca_;
+    uint64_t size_;
+    int ix_orca_min_;
+    int ix_orca_max_;
+    int iy_orca_min_;
+    int iy_orca_max_;
+    uint64_t nx_orca_;
+    uint64_t ny_orca_;
+    uint64_t nb_used_nodes_;
+    uint64_t nb_used_real_nodes_;
+    uint64_t nb_used_ghost_nodes_;
+    uint64_t nb_cells_;
+    double lon00_;
+    util::NormaliseLongitude lon00_normaliser_;
+};
+}  // namespace atlas::orca::meshgenerator

--- a/src/atlas-orca/meshgenerator/LocalOrcaGrid.h
+++ b/src/atlas-orca/meshgenerator/LocalOrcaGrid.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2021- ECMWF.
+ * (C) Crown Copyright 2024 Met Office
  *
  * This software is licensed under the terms of the Apache Licence Version 2.0
  * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.

--- a/src/atlas-orca/meshgenerator/LocalOrcaGrid.h
+++ b/src/atlas-orca/meshgenerator/LocalOrcaGrid.h
@@ -39,6 +39,7 @@ class LocalOrcaGrid {
     std::vector<int> is_ghost_including_orca_halo;
     std::vector<int> is_ghost;
     std::vector<int> is_node;
+    std::vector<int> is_cell;
     uint64_t size() const {return size_;}
     int ix_min() const {return ix_orca_min_;}
     int ix_max() const {return ix_orca_max_;}
@@ -54,6 +55,10 @@ class LocalOrcaGrid {
     uint64_t nb_used_nodes() const {return nb_used_nodes_;}
     // number of cells on this partition
     uint64_t nb_cells() const {return nb_cells_;}
+    // number of ghost cells on this partition
+    uint64_t nb_used_ghost_cells() const {return nb_used_ghost_cells_;}
+    // number of real cells on this paritition
+    uint64_t nb_used_real_cells() const {return nb_used_real_cells_;}
 
     int index( idx_t ix, idx_t iy ) const;
     LocalOrcaGrid( const OrcaGrid& grid, const SurroundingRectangle& rectangle );
@@ -67,6 +72,7 @@ class LocalOrcaGrid {
     idx_t orca_haloed_global_grid_index( idx_t ix, idx_t iy ) const;
     void flags( idx_t ix, idx_t iy, util::detail::BitflagsView<int>& flag_view ) const;
     bool water( idx_t ix, idx_t iy ) const;
+    bool orca_halo( idx_t ix, idx_t iy ) const;
 
  private:
     const OrcaGrid orca_;
@@ -81,6 +87,8 @@ class LocalOrcaGrid {
     uint64_t nb_used_real_nodes_;
     uint64_t nb_used_ghost_nodes_;
     uint64_t nb_cells_;
+    uint64_t nb_used_ghost_cells_;
+    uint64_t nb_used_real_cells_;
     double lon00_;
     util::NormaliseLongitude lon00_normaliser_;
 };

--- a/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
+++ b/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
@@ -489,8 +489,7 @@ void OrcaMeshGenerator::build_remote_index(Mesh& mesh) const {
     Unique2Node global2local;
     for ( idx_t jnode = 0; jnode < nodes.size(); ++jnode ) {
         gidx_t uid = master_glb_idx( jnode );
-        if ( ( part( jnode ) != mypart ) ||
-             ( ( master_glb_idx( jnode ) != glb_idx( jnode ) ) && ( part( jnode ) == mypart ) ) ) {
+        if ( ghost( jnode ) ) {
             send_uid[part( jnode )].push_back( uid );
             req_lidx[part( jnode )].push_back( jnode );
             ridx( jnode ) = -1;

--- a/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
+++ b/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
@@ -375,7 +375,7 @@ void OrcaMeshGenerator::generate( const Grid& grid, const grid::Distribution& di
 
                     cells.node_connectivity.set( jcell, quad_nodes.data() );
                     cells.part( jcell )    = nodes.part( quad_nodes[0] );
-                    cells.glb_idx( jcell ) = ( iy_glb - iy_glb_min ) * ( nx_orca_halo - 1 ) + ( ix_glb - ix_glb_min ) + 1;
+                    cells.glb_idx( jcell ) = ( iy_glb - iy_glb_min ) * nx_orca_halo + ( ix_glb - ix_glb_min ) + 1;
 
                     if ( iy_glb >= SR_cfg.ny_glb - 1 ) {
                         cells.flags( jcell ).set( Topology::GHOST );
@@ -427,7 +427,8 @@ void OrcaMeshGenerator::generate( const Grid& grid, const grid::Distribution& di
                     if ( elem_contains_land_point ) {
                         cells.flags( jcell ).set( Topology::LAND );
                     }
-                    if ( orca_grid.invalidElement( local_orca.ix_min() + ix, local_orca.iy_min() + iy ) ) {
+                    const auto ij_glb = local_orca.orca_haloed_global_grid_ij( ix, iy );
+                    if ( orca_grid.invalidElement( ij_glb.i, ij_glb.j ) ) {
                         cells.flags( jcell ).set( Topology::INVALID );
                     }
                 }

--- a/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
+++ b/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
@@ -53,39 +53,6 @@
 
 namespace atlas::orca::meshgenerator {
 
-// ORCA2 interesting indices
-static const std::vector<std::pair<int, int>> glb_ij_pairs{
-    {0, 148},
-    {1, 148},
-    {0, 147},
-    {89, 148},
-    {90, 148},
-    {91, 148},
-    {92, 148},
-    {93, 148},
-    //89-90, 147
-    {89, 147},
-    {90, 147},
-    //92-101, 147
-    {92, 147},
-    {93, 147},
-    {94, 147},
-    {95, 147},
-    {96, 147},
-    {97, 147},
-    {98, 147},
-    {99, 147},
-    {100, 147},
-    {101, 147},
-    //89-90, 146
-    {89, 146},
-    {90, 146},
-    //180-181, 148
-    {180, 148},
-    {181, 148},
-    {181, 146},
-};
-
 namespace {
 
 StructuredGrid equivalent_regular_grid( const OrcaGrid& orca ) {

--- a/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
+++ b/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
@@ -306,7 +306,7 @@ void OrcaMeshGenerator::generate( const Grid& grid, const grid::Distribution& di
                       nodes.master_glb_idx( inode ) = master_idx + 1;
                       if ( nparts_ == 1 ) {
                         nodes.part( inode ) = 0;
-                      } else {                        
+                      } else {
                         PointIJ master_ij = local_orca.master_global_ij( ix, iy );
                         auto clamp = []( idx_t value, idx_t lower, idx_t upper ) {
                           // in C++17 this is std::clamp
@@ -562,7 +562,7 @@ OrcaMeshGenerator::OrcaMeshGenerator( const eckit::Parametrisation& config ) {
     config.get( "halo", halosize_);
     if ( halosize_ < 0 ) {
       throw_NotImplemented("Halo size must be >= 0", Here());
-    } 
+    }
 }
 
 void OrcaMeshGenerator::generate( const Grid& grid, const grid::Partitioner& partitioner, Mesh& mesh ) const {

--- a/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
+++ b/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
@@ -404,7 +404,7 @@ void OrcaMeshGenerator::generate( const Grid& grid, const grid::Distribution& di
             }
         }
     }
-    ATLAS_DEBUG_VAR( serial_distribution );
+    // ATLAS_DEBUG_VAR( serial_distribution );
     if ( serial_distribution ) {
         // Bypass for "BuildParallelFields"
         mesh.nodes().metadata().set( "parallel", true );
@@ -413,7 +413,7 @@ void OrcaMeshGenerator::generate( const Grid& grid, const grid::Distribution& di
         mesh.metadata().set( "periodic", true );
     }
     else {
-        ATLAS_DEBUG( "build_remote_index" );
+        // ATLAS_DEBUG( "build_remote_index" );
         build_remote_index( mesh );
     }
 
@@ -436,7 +436,7 @@ void OrcaMeshGenerator::build_remote_index(Mesh& mesh) const {
     nodes.metadata().get( "parallel", parallel );
     mesh.metadata().get( "periodic", periodic );
     if ( parallel || periodic ) {
-        ATLAS_DEBUG( "build_remote_index: already parallel, return" );
+        // ATLAS_DEBUG( "build_remote_index: already parallel, return" );
         return;
     }
 

--- a/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
+++ b/src/atlas-orca/meshgenerator/OrcaMeshGenerator.cc
@@ -241,9 +241,11 @@ void OrcaMeshGenerator::generate( const Grid& grid, const grid::Distribution& di
 
                     // grid ij coordinates
                     {
-                      const auto ij_glb = local_orca.orca_haloed_global_grid_ij( ix, iy );
-                      nodes.ij( inode, XX ) = ij_glb.i;
-                      nodes.ij( inode, YY ) = ij_glb.j;
+                      //   const auto ij_glb = local_orca.orca_haloed_global_grid_ij( ix, iy );
+                      //   nodes.ij( inode, XX ) = ij_glb.i;
+                      //   nodes.ij( inode, YY ) = ij_glb.j;
+                      nodes.ij( inode, XX ) = ix + local_orca.ix_min();
+                      nodes.ij( inode, YY ) = iy + local_orca.iy_min();
                     }
 
                     const auto normalised_xy = local_orca.normalised_grid_xy( ix, iy );

--- a/src/atlas-orca/meshgenerator/OrcaMeshGenerator.h
+++ b/src/atlas-orca/meshgenerator/OrcaMeshGenerator.h
@@ -13,6 +13,10 @@
 #include "atlas/meshgenerator/MeshGenerator.h"
 #include "atlas/meshgenerator/detail/MeshGeneratorImpl.h"
 #include "atlas/util/Config.h"
+#include "atlas/grid/Distribution.h"
+#include "atlas-orca/grid/OrcaGrid.h"
+#include "atlas-orca/meshgenerator/SurroundingRectangle.h"
+
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace eckit {
@@ -51,13 +55,13 @@ public:
 
 private:
     void hash( eckit::Hash& ) const override;
-    static void build_remote_index( Mesh& mesh );
+    void build_remote_index(Mesh& mesh) const;
 
     bool include_pole_{ false };
     bool fixup_{ true };
     int nparts_;
     int mypart_;
-    int halo_;
+    int halosize_{0};
 };
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/atlas-orca/meshgenerator/SurroundingRectangle.cc
+++ b/src/atlas-orca/meshgenerator/SurroundingRectangle.cc
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2021- ECMWF.
+ * (C) Crown Copyright 2024 Met Office
  *
  * This software is licensed under the terms of the Apache Licence Version 2.0
  * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
@@ -175,7 +175,7 @@ SurroundingRectangle::SurroundingRectangle(
       for ( idx_t ix = 0; ix < nx_; ix++ ) {
         idx_t ii = index( ix, iy );
         parts.at( ii ) = partition( ix, iy );
-        
+
         PointIJ pij = global_periodic_ij( ix_min_ + ix, iy_min_ + iy );
         bool periodic_point = ( (pij.i != (ix_min_ + ix) ) || (pij.j != (iy_min_ + iy)) );
         bool halo_found = false;
@@ -205,8 +205,8 @@ SurroundingRectangle::SurroundingRectangle(
             }
           }
           ATLAS_ASSERT_MSG( halo_found, std::string("Halo distance not found at point ") +
-                                        std::to_string(ix) + std::string(", ") + 
-                                        std::to_string(iy) ); 
+                                        std::to_string(ix) + std::string(", ") +
+                                        std::to_string(iy) );
           halo.at( ii ) = halo_dist;
         }
         is_ghost.at( ii ) = ( (parts.at( ii ) != cfg_.mypart) || periodic_point );
@@ -215,4 +215,4 @@ SurroundingRectangle::SurroundingRectangle(
   }
 }
 
-}  // namespace atlas::orca::meshgenerator 
+}  // namespace atlas::orca::meshgenerator

--- a/src/atlas-orca/meshgenerator/SurroundingRectangle.cc
+++ b/src/atlas-orca/meshgenerator/SurroundingRectangle.cc
@@ -160,7 +160,7 @@ SurroundingRectangle::SurroundingRectangle(
   ny_ = iy_max_ - iy_min_ + 1;
 
   // upper estimate for number of nodes
-  uint64_t size = ny_ * nx_;
+  int64_t size = ny_ * nx_;
 
   // partitions and local indices in SR
   parts.resize( size, -1 );

--- a/src/atlas-orca/meshgenerator/SurroundingRectangle.cc
+++ b/src/atlas-orca/meshgenerator/SurroundingRectangle.cc
@@ -1,0 +1,226 @@
+/*
+ * (C) Copyright 2021- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include "SurroundingRectangle.h"
+
+#include <algorithm>
+#include <numeric>
+#include <utility>
+#include <fstream>
+#include <iomanip>
+
+#include "atlas/array/Array.h"
+#include "atlas/field/Field.h"
+#include "atlas/grid/Distribution.h"
+#include "atlas/grid/Partitioner.h"
+#include "atlas/parallel/mpi/mpi.h"
+#include "atlas/runtime/Exception.h"
+#include "atlas/runtime/Log.h"
+#include "atlas/util/Constants.h"
+#include "atlas/util/CoordinateEnums.h"
+#include "atlas/util/Geometry.h"
+
+
+namespace atlas::orca::meshgenerator {
+
+namespace {
+int wrap( idx_t value, idx_t lower, idx_t upper ) {
+  // wrap around coordinate system when out of bounds
+  const idx_t width = upper - lower;
+  if (value < lower) {
+    return wrap(value + width, lower, upper);
+  }
+  if (value >= upper) {
+    return wrap(value - width, lower, upper);
+  }
+  return value;
+}
+}  // namespace
+
+
+PointIJ SurroundingRectangle::global_periodic_ij(idx_t ix_glb, idx_t iy_glb) const {
+  // wrap around coordinate system when out of bounds on the global rectangle
+
+  // use global ij on rectangle
+  const idx_t width_x = cfg_.nx_glb;
+  const idx_t ix_glb_max = cfg_.nx_glb - 1;
+  const idx_t iy_glb_max = cfg_.ny_glb - 1;
+  idx_t ix_glb_p = ix_glb;
+  idx_t iy_glb_p = iy_glb;
+
+  // j index north/south boundaries
+  if (iy_glb_p > iy_glb_max) {
+    ix_glb_p = ix_glb_p + width_x/2;
+    iy_glb_p = 2*iy_glb_max - iy_glb_p;
+  }
+  if (iy_glb_p < 0) {
+    ix_glb_p = ix_glb_p + width_x/2;
+    iy_glb_p = -iy_glb_p;
+  }
+
+  //// i index periodic east/west boundaries
+  if (ix_glb_p < 0) {
+    ix_glb_p = wrap(ix_glb_p + width_x, 0, cfg_.nx_glb);
+  }
+  if (ix_glb_p > ix_glb_max) {
+    ix_glb_p = wrap(ix_glb_p - width_x, 0, cfg_.nx_glb);
+  }
+
+  // convert to local ij on rectangle
+  return PointIJ(ix_glb_p, iy_glb_p);
+}
+
+int SurroundingRectangle::index( int ix, int iy ) const {
+  ATLAS_ASSERT_MSG(ix < nx_, std::string("ix >= nx_: ") + std::to_string(ix) + " >= " + std::to_string(nx_));
+  ATLAS_ASSERT_MSG(iy < ny_, std::string("iy >= ny_: ") + std::to_string(iy) + " >= " + std::to_string(ny_));
+  return iy * nx_ + ix;
+}
+
+int SurroundingRectangle::partition( idx_t i, idx_t j ) const {
+  PointIJ ij = this->global_periodic_ij(ix_min_ + i, iy_min_ + j);
+  ATLAS_ASSERT_MSG(ij.i < cfg_.nx_glb, std::string("ix >= cfg_.nx_glb: ") + std::to_string(ij.i) + " >= " + std::to_string(cfg_.nx_glb) + " ix_min_ " + std::to_string(ix_min_));
+  ATLAS_ASSERT_MSG(ij.j < cfg_.ny_glb, std::string("iy >= cfg_.ny_glb: ") + std::to_string(ij.j) + " >= " + std::to_string(cfg_.ny_glb) + " iy_min_ " + std::to_string(iy_min_));
+  return distribution_.partition( ij.j * cfg_.nx_glb + ij.i );
+}
+
+int SurroundingRectangle::global_partition( idx_t ix_glb, idx_t iy_glb ) const {
+  PointIJ ij = this->global_periodic_ij(ix_glb, iy_glb);
+  auto ix_glb_p = ij.i;
+  auto iy_glb_p = ij.j;
+  ATLAS_ASSERT_MSG(ix_glb_p < cfg_.nx_glb, std::string("ix >= cfg_.nx_glb: ") + std::to_string(ix_glb_p) + " >= " + std::to_string(cfg_.nx_glb));
+  ATLAS_ASSERT_MSG(iy_glb_p < cfg_.ny_glb, std::string("iy >= cfg_.ny_glb: ") + std::to_string(iy_glb_p) + " >= " + std::to_string(cfg_.ny_glb));
+  return distribution_.partition( iy_glb_p * cfg_.nx_glb + ix_glb_p );
+}
+
+SurroundingRectangle::SurroundingRectangle(
+    const grid::Distribution& distribution,
+    const Configuration& cfg )
+  : distribution_(distribution), cfg_(cfg) {
+  ATLAS_TRACE();
+  cfg_.check_consistency();
+
+//  std::ofstream logFile(distribution.type() + "-"
+//      + std::to_string(cfg_.halosize) + "_p"
+//      + std::to_string(cfg_.mypart) + ".log");
+
+  // determine rectangle (ix_min_:ix_max_) x (iy_min_:iy_max_) surrounding the nodes on this processor
+  ix_min_         = cfg_.nx_glb;
+  ix_max_         = 0;
+  iy_min_         = cfg_.ny_glb;
+  iy_max_         = 0;
+  nb_real_nodes_owned_by_rectangle = 0;
+
+  // TODO: These "bounds"  are on the imaginary wrapped rectangle including halo and periodic points.
+  // points out of bounds of the reglatlon grid are either in the orca halo points, or are in the halo
+  {
+    ATLAS_TRACE( "find rectangle bounds" );
+    atlas_omp_parallel {
+      int ix_min_TP = ix_min_;
+      int ix_max_TP = ix_max_;
+      int iy_min_TP = iy_min_;
+      int iy_max_TP = iy_max_;
+      int nb_real_nodes_owned_by_rectangle_TP = 0;
+      atlas_omp_for( idx_t iy_glb = 0; iy_glb < cfg_.ny_glb; iy_glb++ ) {
+        for ( idx_t ix_glb = 0; ix_glb < cfg_.nx_glb; ix_glb++ ) {
+          ATLAS_ASSERT_MSG(ix_glb < cfg_.nx_glb, std::string("ix_glb >= cfg_.nx_glb: ") + std::to_string(ix_glb) + " >= " + std::to_string(cfg_.nx_glb));
+          ATLAS_ASSERT_MSG(iy_glb < cfg_.ny_glb, std::string("iy_glb >= cfg_.ny_glb: ") + std::to_string(iy_glb) + " >= " + std::to_string(cfg_.ny_glb));
+          int p = global_partition( ix_glb, iy_glb );
+          if ( p == cfg_.mypart ) {
+            ix_min_TP = std::min<idx_t>( ix_min_TP, ix_glb );
+            ix_max_TP = std::max<idx_t>( ix_max_TP, ix_glb );
+            iy_min_TP = std::min<idx_t>( iy_min_TP, iy_glb );
+            iy_max_TP = std::max<idx_t>( iy_max_TP, iy_glb );
+            nb_real_nodes_owned_by_rectangle_TP++;
+          }
+        }
+      }
+      atlas_omp_critical {
+        nb_real_nodes_owned_by_rectangle += nb_real_nodes_owned_by_rectangle_TP;
+        ix_min_ = std::min<int>( ix_min_TP, ix_min_);
+        ix_max_ = std::max<int>( ix_max_TP, ix_max_);
+        iy_min_ = std::min<int>( iy_min_TP, iy_min_);
+        iy_max_ = std::max<int>( iy_max_TP, iy_max_);
+      }
+    }
+  }
+
+  // add the halo.
+  ix_min_ -= cfg_.halosize;
+  ix_max_ += cfg_.halosize;
+  iy_min_ -= cfg_.halosize;
+  iy_max_ += cfg_.halosize;
+
+  // +1 to surround the ghost nodes used to complete the cells
+  ix_max_ += 1;
+  iy_max_ += 1;
+
+  // dimensions of the surrounding rectangle (+1 because the size of the dimension is one bigger than the index of the last element)
+  nx_ = ix_max_ - ix_min_ + 1;
+  ny_ = iy_max_ - iy_min_ + 1;
+
+//  logFile << "[" << cfg_.mypart << "] ix_min: "     << ix_min_ << std::endl;
+//  logFile << "[" << cfg_.mypart << "] ix_max: "     << ix_max_ << std::endl;
+//  logFile << "[" << cfg_.mypart << "] iy_min: "     << iy_min_ << std::endl;
+//  logFile << "[" << cfg_.mypart << "] iy_max: "     << iy_max_ << std::endl;
+
+  // upper estimate for number of nodes
+  uint64_t size = ny_ * nx_;
+
+  // partitions and local indices in SR
+  parts.resize( size, -1 );
+  halo.resize( size, 0 );
+  is_ghost.resize( size, true );
+  // vectors marking nodes that are necessary for this proc's cells
+
+  {
+    ATLAS_TRACE( "partition, is_ghost, halo" );
+    //atlas_omp_parallel_for( idx_t iy = 0; iy < ny_; iy++ )
+    for( idx_t iy = 0; iy < ny_; iy++ ) {
+      for ( idx_t ix = 0; ix < nx_; ix++ ) {
+        idx_t ii = index( ix, iy );
+        parts.at( ii ) = partition( ix, iy );
+        bool halo_found = false;
+        int halo_dist = cfg_.halosize;
+        if ((cfg_.halosize > 0) && parts.at( ii ) != cfg_.mypart ) {
+          // search the surrounding halosize index square for a node on my
+          // partition to determine the halo distance
+          for (idx_t dhy = -cfg_.halosize; dhy <= cfg_.halosize; ++dhy) {
+            for (idx_t dhx = -cfg_.halosize; dhx <= cfg_.halosize; ++dhx) {
+              if (dhx == 0 && dhy == 0) continue;
+              if (partition(ix + dhx, iy + dhy) == cfg_.mypart) {
+                // find the minimum distance from this halo node to
+                // a node on the partition
+                auto dist = std::max(std::abs(dhx), std::abs(dhy));
+                halo_dist = std::min(dist, halo_dist);
+                halo_found = true;
+              }
+            }
+          }
+          if (halo_found) {
+            halo.at( ii ) = halo_dist;
+          }
+        }
+
+        is_ghost.at( ii ) = ( parts.at( ii ) != cfg_.mypart );
+      }
+    }
+  }
+//  logFile << std::setw(5) << std::setfill('0');
+//  logFile << "[" << cfg_.mypart << "] nx                      = " << nx_ << std::endl;
+//  logFile << "[" << cfg_.mypart << "] ny                      = " << ny_ << std::endl;
+//  logFile << "[" << cfg_.mypart << "] halosize                = " << cfg_.halosize << std::endl;
+//  logFile << "[" << cfg_.mypart << "] ny * nx_                = " << ny_ * nx_ << std::endl;
+//  logFile << "[" << cfg_.mypart << "] ny * (nx_ + 2*halosize) = " << ny_ * (nx_ + 2*cfg_.halosize) << std::endl;
+//  logFile << "[" << cfg_.mypart << "] nb_real_nodes_owned_by_rectangle = " << nb_real_nodes_owned_by_rectangle << std::endl;
+//  logFile << "[" << cfg_.mypart << "] end of SR output" << std::endl;
+//  logFile.close();
+}
+
+}  // namespace atlas::orca::meshgenerator 

--- a/src/atlas-orca/meshgenerator/SurroundingRectangle.h
+++ b/src/atlas-orca/meshgenerator/SurroundingRectangle.h
@@ -79,6 +79,7 @@ class SurroundingRectangle {
     int iy_min() const { return iy_min_; };
     int ix_max() const { return ix_max_; };
     int iy_max() const { return iy_max_; };
+    int halosize() const { return halosize_; };
     uint64_t nb_real_nodes_owned_by_rectangle;
 
  private:
@@ -88,5 +89,6 @@ class SurroundingRectangle {
     uint64_t nx_, ny_;
     int ix_min_, ix_max_;
     int iy_min_, iy_max_;
+    int halosize_;
 };
 }  // namespace atlas::orca::meshgenerator 

--- a/src/atlas-orca/meshgenerator/SurroundingRectangle.h
+++ b/src/atlas-orca/meshgenerator/SurroundingRectangle.h
@@ -1,0 +1,92 @@
+/*
+ * (C) Copyright 2021- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#pragma once
+
+#include "eckit/exception/Exceptions.h" 
+#include "atlas/meshgenerator/MeshGenerator.h"
+#include "atlas/meshgenerator/detail/MeshGeneratorImpl.h"
+#include "atlas/util/Config.h"
+#include "atlas/grid/Distribution.h"
+#include "atlas-orca/grid/OrcaGrid.h"
+#include "atlas-orca/util/PointIJ.h"
+
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+namespace eckit {
+class Parametrisation;
+}
+
+namespace atlas {
+class OrcaGrid;
+}  // namespace atlas
+
+namespace atlas {
+namespace grid {
+class Distribution;
+}  // namespace grid
+}  // namespace atlas
+#endif
+
+namespace atlas::orca::meshgenerator {
+
+//----------------------------------------------------------------------------------------------------------------------
+//
+class SurroundingRectangle {
+ public:
+    struct Configuration {
+        int nparts;
+        int mypart;
+        int halosize;
+        int nx_glb;
+        int ny_glb;
+        Configuration() :
+            nparts(std::numeric_limits<int>::lowest())
+            , mypart(std::numeric_limits<int>::lowest())
+            , halosize(std::numeric_limits<int>::lowest())
+            , nx_glb(std::numeric_limits<int>::lowest())
+            , ny_glb(std::numeric_limits<int>::lowest()) {}
+        void check_consistency() const {
+            const auto check = [&](const int value) {
+                if (value == std::numeric_limits<int>::lowest())
+                  eckit::BadParameter("atlas-orca/meshgenerator/SurroundingRectangle: not all parameters set"); 
+            };
+            check(nparts);
+            check(mypart);
+            check(halosize);
+            check(nx_glb);
+            check(ny_glb);
+        }
+    };
+    SurroundingRectangle(const grid::Distribution& distribution, const Configuration& cfg);
+    PointIJ global_periodic_ij( idx_t ix, idx_t iy ) const;
+    int index( int i, int j ) const;
+    int partition( idx_t i, idx_t j ) const;
+    int global_partition( idx_t ix_glb, idx_t iy_glb ) const;
+    std::vector<int> parts;
+    std::vector<int> halo;
+    std::vector<int> is_ghost;
+    uint64_t nx() const { return nx_; };
+    uint64_t ny() const { return ny_; };
+    int ix_min() const { return ix_min_; };
+    int iy_min() const { return iy_min_; };
+    int ix_max() const { return ix_max_; };
+    int iy_max() const { return iy_max_; };
+    uint64_t nb_real_nodes_owned_by_rectangle;
+
+ private:
+    const grid::Distribution distribution_;
+    const OrcaGrid orca_;
+    const Configuration cfg_;
+    uint64_t nx_, ny_;
+    int ix_min_, ix_max_;
+    int iy_min_, iy_max_;
+};
+}  // namespace atlas::orca::meshgenerator 

--- a/src/atlas-orca/meshgenerator/SurroundingRectangle.h
+++ b/src/atlas-orca/meshgenerator/SurroundingRectangle.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2021- ECMWF.
+ * (C) Crown Copyright 2024 Met Office
  *
  * This software is licensed under the terms of the Apache Licence Version 2.0
  * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
@@ -10,7 +10,7 @@
 
 #pragma once
 
-#include "eckit/exception/Exceptions.h" 
+#include "eckit/exception/Exceptions.h"
 #include "atlas/meshgenerator/MeshGenerator.h"
 #include "atlas/meshgenerator/detail/MeshGeneratorImpl.h"
 #include "atlas/util/Config.h"
@@ -56,7 +56,7 @@ class SurroundingRectangle {
         void check_consistency() const {
             const auto check = [&](const int value) {
                 if (value == std::numeric_limits<int>::lowest())
-                  eckit::BadParameter("atlas-orca/meshgenerator/SurroundingRectangle: not all parameters set"); 
+                  eckit::BadParameter("atlas-orca/meshgenerator/SurroundingRectangle: not all parameters set");
             };
             check(nparts);
             check(mypart);
@@ -91,4 +91,4 @@ class SurroundingRectangle {
     int iy_min_, iy_max_;
     int halosize_;
 };
-}  // namespace atlas::orca::meshgenerator 
+}  // namespace atlas::orca::meshgenerator

--- a/src/atlas-orca/meshgenerator/SurroundingRectangle.h
+++ b/src/atlas-orca/meshgenerator/SurroundingRectangle.h
@@ -73,20 +73,20 @@ class SurroundingRectangle {
     std::vector<int> parts;
     std::vector<int> halo;
     std::vector<int> is_ghost;
-    uint64_t nx() const { return nx_; };
-    uint64_t ny() const { return ny_; };
+    int64_t nx() const { return nx_; };
+    int64_t ny() const { return ny_; };
     int ix_min() const { return ix_min_; };
     int iy_min() const { return iy_min_; };
     int ix_max() const { return ix_max_; };
     int iy_max() const { return iy_max_; };
     int halosize() const { return halosize_; };
-    uint64_t nb_real_nodes_owned_by_rectangle;
+    int64_t nb_real_nodes_owned_by_rectangle;
 
  private:
     const grid::Distribution distribution_;
     const OrcaGrid orca_;
     const Configuration cfg_;
-    uint64_t nx_, ny_;
+    int64_t nx_, ny_;
     int ix_min_, ix_max_;
     int iy_min_, iy_max_;
     int halosize_;

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -40,8 +40,47 @@ ecbuild_add_test( TARGET  atlas_test_orca_polygon_locator
                   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
                   CONDITION eckit_HAVE_LZ4 AND eckit_HAVE_MPI)
 
-ecbuild_add_test( TARGET  atlas_test_orca_mesh_boundaries
+ecbuild_add_test( TARGET  atlas_test_orca_mesh_boundaries_NOMPI
                   SOURCES test_orca_mesh_boundaries.cc
+                  LIBS    atlas-orca
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+                  CONDITION eckit_HAVE_LZ4)
+
+ecbuild_add_test( TARGET  atlas_test_orca_mesh_boundaries_MPI2
+                  SOURCES test_orca_mesh_boundaries.cc
+                  LIBS    atlas-orca
+                  MPI     2
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+                  CONDITION eckit_HAVE_LZ4  AND eckit_HAVE_MPI)
+
+ecbuild_add_test( TARGET  atlas_test_orca_surrounding_rectangle_NOMPI
+                  SOURCES test_orca_surrounding_rectangle.cc
+                  LIBS    atlas-orca
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+                  CONDITION eckit_HAVE_LZ4 )
+
+ecbuild_add_test( TARGET  atlas_test_orca_surrounding_rectangle_MPI2
+                  SOURCES test_orca_surrounding_rectangle.cc
+                  LIBS    atlas-orca
+                  MPI     2
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+                  CONDITION eckit_HAVE_LZ4  AND eckit_HAVE_MPI)
+
+ecbuild_add_test( TARGET  atlas_test_orca_surrounding_rectangle_MPI4
+                  SOURCES test_orca_surrounding_rectangle.cc
+                  LIBS    atlas-orca
+                  MPI     4
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+                  CONDITION eckit_HAVE_LZ4  AND eckit_HAVE_MPI)
+
+ecbuild_add_test( TARGET  atlas_test_orca_local_grid_NOMPI
+                  SOURCES test_orca_local_grid.cc
+                  LIBS    atlas-orca
+                  ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}
+                  CONDITION eckit_HAVE_LZ4)
+
+ecbuild_add_test( TARGET  atlas_test_orca_local_grid_MPI2
+                  SOURCES test_orca_local_grid.cc
                   LIBS    atlas-orca
                   MPI     2
                   ENVIRONMENT ${ATLAS_TEST_ENVIRONMENT}

--- a/src/tests/test_orca_grid.cc
+++ b/src/tests/test_orca_grid.cc
@@ -69,7 +69,10 @@ CASE( "test orca grid iterator" ) {
 }
 
 CASE("test matchup between orca and regular ij indexing ") {
-  std::vector<std::string> gridnames = {"ORCA2_T", "eORCA025_T"};
+  std::vector<std::string> gridnames = {
+    "ORCA2_T",
+    // "eORCA025_T",
+  };
 
   for (const std::string& gridname : gridnames) {
     auto mypart = 0;

--- a/src/tests/test_orca_grid.cc
+++ b/src/tests/test_orca_grid.cc
@@ -123,7 +123,7 @@ CASE("test matchup between orca and regular ij indexing ") {
     const std::array<std::int32_t, 2> dimensions{nx_orca_halo, ny_orca_halo};
     const std::array<std::int32_t, 4> halo{orca_grid.haloNorth(), orca_grid.haloWest(),
                                            orca_grid.haloSouth(), orca_grid.haloEast()};
-    const std::array<double, 2> pivot{orca_grid.nx()/2 + 1, orca_grid.ny()};
+    const std::array<double, 2> pivot{static_cast<double>(orca_grid.nx()/2 + 1), static_cast<double>(orca_grid.ny())};
 
     if (gridname == "ORCA2_T") {
       EXPECT(nx_orca_halo == 182);

--- a/src/tests/test_orca_grid.cc
+++ b/src/tests/test_orca_grid.cc
@@ -8,12 +8,19 @@
  * nor does it submit to any jurisdiction.
  */
 
+#include <algorithm>
+#include <fstream>
+#include <iomanip>
+
 #include "eckit/log/Bytes.h"
 
 #include "atlas/grid.h"
+#include "atlas/grid/Spacing.h"
 #include "atlas/util/Config.h"
 
 #include "atlas-orca/grid/OrcaGrid.h"
+#include "atlas-orca/util/PointIJ.h"
+#include "atlas-orca/util/OrcaPeriodicity.h"
 
 #include "tests/AtlasTestEnvironment.h"
 
@@ -59,6 +66,142 @@ CASE( "test orca grid iterator" ) {
             Log::info() << "Last point: " << grid.lonlat().back() << std::endl;
         }
     }
+}
+
+CASE("test matchup between orca and regular ij indexing ") {
+  std::vector<std::string> gridnames = {"ORCA2_T", "eORCA025_T"};
+
+  for (const std::string& gridname : gridnames) {
+    auto mypart = 0;
+    auto orca_grid = OrcaGrid(gridname);
+
+    StructuredGrid::YSpace yspace{grid::LinearSpacing{
+        {-80., 90.}, orca_grid.ny(), true}};
+    StructuredGrid::XSpace xspace{
+        grid::LinearSpacing{{0., 360.}, orca_grid.nx(), false}};
+    StructuredGrid regular_grid{xspace, yspace};
+
+    SECTION("is the regular grid ij index unique?") {
+      const idx_t size = regular_grid.size();
+      std::set<gidx_t> ij_uid;
+      for (gidx_t node = 0; node < size; ++node) {
+        idx_t i, j;
+        regular_grid.index2ij(node, i, j);
+        ij_uid.insert(i*10*size + j);
+      }
+
+      if (size != ij_uid.size())
+        std::cout << "[" << mypart
+                  << "] number of duplicate regular grid ij UID points "
+                  << size - ij_uid.size()
+                  << "/" << size << std::endl;
+      EXPECT(size == ij_uid.size());
+    }
+
+    SECTION("are the orca grid internal ij indices unique?") {
+      const idx_t size = orca_grid.size();
+      std::set<gidx_t> ij_uid;
+      for (gidx_t node = 0; node < size; ++node) {
+        idx_t i, j;
+        orca_grid.index2ij(node, i, j);
+        if (i >= orca_grid.nx() || i < 0) continue;
+        if (j >= orca_grid.ny() || j < 0) continue;
+        ij_uid.insert(i*10*size + j);
+      }
+      auto internal_size = orca_grid.nx()*orca_grid.ny();
+      if (internal_size != ij_uid.size())
+        std::cout << "[" <<  mypart
+                  << "] number of duplicate orca grid ij UID points "
+                  << internal_size - ij_uid.size()
+                  << "/" << internal_size << std::endl;
+      EXPECT(internal_size == ij_uid.size());
+    }
+
+    auto nx_orca_halo = orca_grid.haloWest() + orca_grid.nx() + orca_grid.haloEast(); 
+    auto ny_orca_halo = orca_grid.haloSouth() + orca_grid.ny() + orca_grid.haloNorth();
+
+    const std::array<std::int32_t, 2> dimensions{nx_orca_halo, ny_orca_halo};
+    const std::array<std::int32_t, 4> halo{orca_grid.haloNorth(), orca_grid.haloWest(),
+                                           orca_grid.haloSouth(), orca_grid.haloEast()};
+    const std::array<double, 2> pivot{orca_grid.nx()/2 + 1, orca_grid.ny()};
+
+    if (gridname == "ORCA2_T") {
+      EXPECT(nx_orca_halo == 182);
+      EXPECT(ny_orca_halo == 149);
+      EXPECT(orca_grid.haloNorth() == 1);
+      EXPECT(orca_grid.haloWest() == 1);
+      EXPECT(orca_grid.haloSouth() == 1);
+      EXPECT(orca_grid.haloEast() == 1);
+      std::cout << "pivot[0]: " << pivot[0] << " =? " << 91 << std::endl;
+      std::cout << "pivot[1]: " << pivot[1] << " =? " << 147 << std::endl;
+      EXPECT(pivot[0] == 91);
+      EXPECT(pivot[1] == 147);
+    }
+
+    atlas::orca::OrcaPeriodicity periodicity(dimensions, halo, pivot);
+
+    SECTION("ORCA periodicity satisfies symmetries") {
+
+      for (idx_t i = 0; i < dimensions[0]; ++i) {
+        for (idx_t j = 0; j < dimensions[1]; ++j) {
+          if (j == orca_grid.ny() && i > orca_grid.nx()/2) {
+            auto master = periodicity(i, j);
+            EXPECT(master.j == orca_grid.ny());
+            EXPECT(master.i == orca_grid.nx() + 2 - i);
+          }
+          // top left corner there are two nodes that don't make sense to me
+          if (j == orca_grid.ny() + 1 && i > 2) {
+            auto master = periodicity(i, j);
+            EXPECT(master.j == orca_grid.ny() - 1);
+            EXPECT(master.i == orca_grid.nx() + 2 - i);
+          }
+        }
+      }
+    }
+
+    SECTION("Are the boundary symmetries present in the orca grid ij indices?") {
+      const idx_t size = orca_grid.size();
+      atlas::PointLonLat lonlat, lonlat_halo;
+      for (gidx_t node = 0; node < size; ++node) {
+        idx_t i, j;
+        orca_grid.index2ij(node, i, j);
+        auto pivot = orca_grid.nx() / 2 + 1;
+        if (gridname.back() == 'U') {
+          pivot = orca_grid.nx() / 2;
+        }
+        if (j == orca_grid.ny() && i > 2) {
+          // check northfold boundary
+          //     - second row is swapped version of second from top row
+          lonlat = orca_grid.lonlat(i, j);
+          lonlat_halo = orca_grid.lonlat(orca_grid.nx() - i, j - 2);
+          EXPECT(orca_grid.periodicIndex(i, j) ==
+                 orca_grid.periodicIndex(orca_grid.nx() - i, j - 2));
+          EXPECT(lonlat[0] == lonlat_halo[0]);
+          EXPECT(lonlat[1] == lonlat_halo[1]);
+        }
+        if (j == orca_grid.ny() - 1) {
+          // check northfold boundary - centre fold row is mirrored about the central pivot
+          if (i <= pivot) continue; // halo points are right of pivot on this row.
+          // count from right-hand-side of grid.
+          lonlat = orca_grid.lonlat(i, j);
+          lonlat_halo = orca_grid.lonlat(orca_grid.nx() - i, j);
+          EXPECT(orca_grid.periodicIndex(i, j) ==
+                 orca_grid.periodicIndex(orca_grid.nx() - i, j));
+          EXPECT(lonlat[0] == lonlat_halo[0]);
+          EXPECT(lonlat[1] == lonlat_halo[1]);
+        }
+        if (i > orca_grid.nx()) {
+          // check east-west boundary
+          lonlat = orca_grid.lonlat(i, j);
+          lonlat_halo = orca_grid.lonlat(orca_grid.nx() - i, j);
+          EXPECT(orca_grid.periodicIndex(i, j) ==
+                 orca_grid.periodicIndex(orca_grid.nx() - i, j));
+          EXPECT(lonlat[0] == lonlat_halo[0]);
+          EXPECT(lonlat[1] == lonlat_halo[1]);
+        }
+      }
+    }
+  }
 }
 
 //-----------------------------------------------------------------------------

--- a/src/tests/test_orca_grid.cc
+++ b/src/tests/test_orca_grid.cc
@@ -117,7 +117,7 @@ CASE("test matchup between orca and regular ij indexing ") {
       EXPECT(internal_size == ij_uid.size());
     }
 
-    auto nx_orca_halo = orca_grid.haloWest() + orca_grid.nx() + orca_grid.haloEast(); 
+    auto nx_orca_halo = orca_grid.haloWest() + orca_grid.nx() + orca_grid.haloEast();
     auto ny_orca_halo = orca_grid.haloSouth() + orca_grid.ny() + orca_grid.haloNorth();
 
     const std::array<std::int32_t, 2> dimensions{nx_orca_halo, ny_orca_halo};

--- a/src/tests/test_orca_local_grid.cc
+++ b/src/tests/test_orca_local_grid.cc
@@ -140,7 +140,7 @@ CASE("test surrounding local_orca ") {
           local_orca.flags( i, j, flags_view );
 
           // check points in the orca halo behave as expected.
-          if (local_orca.orca_halo( i, j ) &&
+          if (local_orca.orca_edge( i, j ) &&
               ((ix_glb >= grid.nx()) || (ix_glb > grid.nx()/2 && iy_glb > grid.ny()))) {
             // this grid point should be a ghost point.
             if ( ohgg_ij.j >= 0 or ohgg_ij.i < 0 or ohgg_ij.i >= grid.nx() ) {

--- a/src/tests/test_orca_local_grid.cc
+++ b/src/tests/test_orca_local_grid.cc
@@ -49,7 +49,7 @@ CASE("test surrounding local_orca ") {
     return 1 + util::function::vortex_rollup(lon, lat, 0.0);
   };
 
-  for (int halo = 0; halo < 2; ++halo) {
+  for (int halo = 0; halo <= 2; ++halo) {
     if ( ( (mpi::size() == 1) && (halo > 0) ) ||
          ( (mpi::size() == 1) && (distributionName != "serial") ) )
       continue;
@@ -84,27 +84,36 @@ CASE("test surrounding local_orca ") {
       int inode_nonghost = 0;
       for (uint64_t j = 0; j < local_orca.ny(); j++) {
         int iy_glb = local_orca.iy_min() + j;
-        EXPECT(iy_glb < grid.ny() + grid.haloNorth() + grid.haloSouth() + halo);
+        ASSERT_MSG(iy_glb < (grid.ny() + std::max(grid.haloNorth(), halo + 1)), "iy_glb in range " +
+                   std::to_string(j) + " " + std::to_string(local_orca.iy_min()) + " " +
+                   std::to_string(iy_glb) + " " + std::to_string(grid.ny()) + " " + 
+                   std::to_string(grid.haloNorth()) + " " + std::to_string(halo));
         for (uint64_t i = 0; i < local_orca.nx(); i++) {
           int ix_glb = local_orca.ix_min() + i;
-          EXPECT(ix_glb < grid.nx() + grid.haloWest() + grid.haloEast() + 2*halo);
+          ASSERT_MSG(ix_glb < (grid.nx() + std::max(grid.haloEast(), halo + 1)), "ix_glb in range " +
+                     std::to_string(i) + " " + std::to_string(local_orca.ix_min()) + " " +
+                     std::to_string(ix_glb) + " " + std::to_string(grid.nx()) + " " + 
+                     std::to_string(grid.haloEast()) + " " + std::to_string(halo));
           auto ii = local_orca.index(i, j);
           indices.emplace_back(ii);
 
-          idx_t reg_grid_glb_idx  = regular_grid.index(ix_glb, iy_glb);
-          idx_t orca_grid_glb_idx = grid.periodicIndex(ix_glb, iy_glb);
-          gidx_t master_idx       = local_orca.master_global_index( i, j );
-          const auto master_global_ij = local_orca.master_global_ij( i, j );
-          ASSERT_MSG(master_global_ij.i < grid.nx(),
-             std::string("master_global_ij.i ") + std::to_string(master_global_ij.i)
-             + " grid.nx() " + std::to_string(grid.nx()) );
-          ASSERT_MSG(master_global_ij.j < grid.ny(),
-             std::string("master_global_ij.j ") + std::to_string(master_global_ij.j)
-             + " grid.ny() " + std::to_string(grid.ny()) );
-          ASSERT_MSG(master_global_ij.i >= -1,
-             std::string("master_global_ij.i ") + std::to_string(master_global_ij.i));
-          ASSERT_MSG(master_global_ij.j >= -1,
-             std::string("master_global_ij.j ") + std::to_string(master_global_ij.j));
+          gidx_t ohgg_idx = local_orca.orca_haloed_global_grid_index( i, j );
+          const auto ohgg_ij = local_orca.orca_haloed_global_grid_ij( i, j );
+          ASSERT_MSG(ohgg_ij.i < grid.nx() + grid.haloEast(),
+             std::string("ohgg_ij.i ") + std::to_string(ohgg_ij.i)
+             + std::string(" grid.nx()) ") + std::to_string(grid.nx()) 
+             + std::string(" grid.haloEast() ") + std::to_string(grid.haloEast()) );
+          ASSERT_MSG(ohgg_ij.j < grid.ny() + grid.haloNorth(),
+             std::string("ohgg_ij.j ") + std::to_string(ohgg_ij.j)
+             + std::string(" grid.ny() ") + std::to_string(grid.ny()) 
+             + std::string(" grid.haloNorth() ") + std::to_string(grid.haloNorth()) );
+          ASSERT_MSG(ohgg_ij.i >= -grid.haloWest(),
+             std::string("ohgg_ij.i ") + std::to_string(ohgg_ij.i)
+             + std::string(" grid.haloWest() ") + std::to_string(grid.haloWest()) );
+          ASSERT_MSG(ohgg_ij.j >= -grid.haloSouth(),
+             std::string("ohgg_ij.j ") + std::to_string(ohgg_ij.j)
+             + std::string(" grid.haloSouth() ") + std::to_string(grid.haloSouth()) );
+
           const auto grid_xy        = local_orca.grid_xy( i, j );
           const auto normed_grid_xy = local_orca.normalised_grid_xy( i, j );
 
@@ -131,19 +140,19 @@ CASE("test surrounding local_orca ") {
           local_orca.flags( i, j, flags_view );
 
           // check points in the orca halo behave as expected.
-          if ((ix_glb > grid.nx()) ||
-              (ix_glb > grid.nx()/2 && iy_glb > grid.ny())) {
-            //std::cout << "ix_glb, iy_glb : " << ix_glb << ", " << iy_glb << " is_ghost "  << local_orca.is_ghost.at(ii)
-            //          << "local_orca.master_global_index(i, j) != local_orca.orca_haloed_global_grid_index(i,j)"
-            //          << local_orca.master_global_index(i, j) << " != " << local_orca.orca_haloed_global_grid_index(i,j)
-            //          << " -- " << grid.ghost( ix_glb, iy_glb ) << std::endl;
+          if (local_orca.orca_halo( i, j ) &&
+              ((ix_glb >= grid.nx()) || (ix_glb > grid.nx()/2 && iy_glb > grid.ny()))) {
             // this grid point should be a ghost point.
-            if ( iy_glb > 0 or ix_glb < 0 ) {
-              EXPECT(local_orca.is_ghost_including_orca_halo.at(ii) >= grid.ghost( ix_glb, iy_glb ));
+            if ( ohgg_ij.j >= 0 or ohgg_ij.i < 0 or ohgg_ij.i >= grid.nx() ) {
+              EXPECT(local_orca.is_ghost_including_orca_halo.at(ii) 
+                     >= grid.ghost( ohgg_ij.i, ohgg_ij.j ));
             }
-            // this grid point should not be a master grid point.
-            //EXPECT(local_orca.master_global_index(i, j)
-            //       != local_orca.orca_haloed_global_grid_index(i,j));
+            if ( (ix_glb >= -grid.haloWest()) && (ix_glb < grid.nx() + grid.haloEast()) &&
+                 (iy_glb >= -grid.haloSouth()) && (iy_glb < grid.ny() + grid.haloNorth())) {
+              // this grid point should not be a master grid point.
+              EXPECT(local_orca.master_global_index(i, j)
+                     != local_orca.orca_haloed_global_grid_index(i,j));
+            }
           }
         }
       }
@@ -186,22 +195,23 @@ CASE("test surrounding local_orca ") {
       }
 
       const idx_t cell_width = 1;
+      // Values below are for ORCA2_T grid.
       if (cfg.nparts == 2) {
         if (cfg.mypart == 0) {
           EXPECT(local_orca.iy_min() == -grid.haloSouth());
-          EXPECT(local_orca.iy_max() == grid.ny() + grid.haloNorth() - 1 + halo);
-          EXPECT(local_orca.ix_min() == -grid.haloWest() - halo);
+          EXPECT(local_orca.iy_max() == grid.ny() + halo);
+          EXPECT(local_orca.ix_min() == -std::max(grid.haloWest(), halo));
           EXPECT(local_orca.ix_max() == 90 + halo);
-          EXPECT(local_orca.nx() == 91 + grid.haloWest() + 2*halo);
-          EXPECT(local_orca.ny() == grid.ny() + grid.haloSouth() + grid.haloNorth() + halo);
+          EXPECT(local_orca.nx() == 91 + halo + std::max(grid.haloWest(), halo));
+          EXPECT(local_orca.ny() == grid.ny() + grid.haloSouth() + halo + 1);
         }
         if (cfg.mypart == 1) {
           EXPECT(local_orca.iy_min() == -grid.haloSouth());
-          EXPECT(local_orca.iy_max() == grid.ny() + grid.haloNorth() - 1 + halo);
+          EXPECT(local_orca.iy_max() == grid.ny() + halo);
           EXPECT(local_orca.ix_min() == 90 - halo);
-          EXPECT(local_orca.ix_max() == grid.nx() + grid.haloEast() - 1 + halo);
-          EXPECT(local_orca.nx() == 90 + grid.haloEast() + 2*halo);
-          EXPECT(local_orca.ny() == grid.ny() + grid.haloSouth() + grid.haloNorth() + halo);
+          EXPECT(local_orca.ix_max() == grid.nx() + halo);
+          EXPECT(local_orca.nx() == grid.nx() + 2 * halo - 89);
+          EXPECT(local_orca.ny() == grid.ny() + grid.haloSouth() + halo + 1);
         }
       }
     }

--- a/src/tests/test_orca_local_grid.cc
+++ b/src/tests/test_orca_local_grid.cc
@@ -1,0 +1,214 @@
+/*
+ * (C) Copyright 2021- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include <algorithm>
+#include <sstream>
+#include <fstream>
+#include <iomanip>
+
+#include "atlas-orca/meshgenerator/SurroundingRectangle.h"
+#include "atlas-orca/meshgenerator/LocalOrcaGrid.h"
+#include "atlas/functionspace/NodeColumns.h"
+#include "atlas/grid.h"
+#include "atlas/grid/Spacing.h"
+#include "atlas/grid/StructuredGrid.h"
+#include "atlas/mesh.h"
+#include "atlas/meshgenerator.h"
+#include "atlas/output/Gmsh.h"
+#include "atlas/parallel/mpi/mpi.h"
+#include "atlas/util/Config.h"
+#include "atlas/util/function/VortexRollup.h"
+#include "atlas/util/Point.h"
+#include "atlas/util/Bitflags.h"
+
+#include "atlas-orca/grid/OrcaGrid.h"
+#include "atlas-orca/util/PointIJ.h"
+
+#include "tests/AtlasTestEnvironment.h"
+
+using Grid = atlas::Grid;
+using Config = atlas::util::Config;
+
+namespace atlas {
+namespace test {
+
+//-----------------------------------------------------------------------------
+
+CASE("test surrounding local_orca ") {
+  std::string gridname = "ORCA2_T";
+  std::string distributionName = "checkerboard";
+
+  auto rollup_plus = [](const double lon, const double lat) {
+    return 1 + util::function::vortex_rollup(lon, lat, 0.0);
+  };
+
+  for (int halo = 0; halo < 2; ++halo) {
+    if ( ( (mpi::size() == 1) && (halo > 0) ) ||
+         ( (mpi::size() == 1) && (distributionName != "serial") ) )
+      continue;
+    SECTION(gridname + "_" + distributionName + "_halo" + std::to_string(halo)) {
+      auto grid = OrcaGrid(gridname);
+      auto partitioner_config = Config();
+      partitioner_config.set("type", distributionName);
+      auto partitioner = grid::Partitioner(partitioner_config);
+      StructuredGrid::YSpace yspace{grid::LinearSpacing{
+          {-80., 90.}, grid.ny(), true}};
+      StructuredGrid::XSpace xspace{
+          grid::LinearSpacing{{0., 360.}, grid.nx(), false}};
+      StructuredGrid regular_grid{xspace, yspace};
+      auto distribution = grid::Distribution(regular_grid, partitioner);
+
+      orca::meshgenerator::SurroundingRectangle::Configuration cfg;
+      cfg.mypart = mpi::rank();
+      cfg.nparts = mpi::size();
+      cfg.halosize = halo;
+      cfg.nx_glb = grid.nx();
+      cfg.ny_glb = grid.ny();
+      orca::meshgenerator::SurroundingRectangle rectangle(distribution, cfg);
+      std::cout << "[" << cfg.mypart << "] rectangle.ix_min " <<  rectangle.ix_min()
+                << " rectangle.ix_max " <<  rectangle.ix_max()
+                << " rectangle.iy_min " <<  rectangle.iy_min()
+                << " rectangle.iy_max " <<  rectangle.iy_max() << std::endl;
+      orca::meshgenerator::LocalOrcaGrid local_orca(grid, rectangle);
+
+      std::vector<idx_t> indices;
+      std::vector<bool> this_partition;
+      int inode_ghost = local_orca.nb_used_real_nodes();  // orca ghost nodes start counting after nonghost nodes
+      int inode_nonghost = 0;
+      for (uint64_t j = 0; j < local_orca.ny(); j++) {
+        int iy_glb = local_orca.iy_min() + j;
+        EXPECT(iy_glb < grid.ny() + grid.haloNorth() + grid.haloSouth() + halo);
+        for (uint64_t i = 0; i < local_orca.nx(); i++) {
+          int ix_glb = local_orca.ix_min() + i;
+          EXPECT(ix_glb < grid.nx() + grid.haloWest() + grid.haloEast() + 2*halo);
+          auto ii = local_orca.index(i, j);
+          indices.emplace_back(ii);
+
+          idx_t reg_grid_glb_idx  = regular_grid.index(ix_glb, iy_glb);
+          idx_t orca_grid_glb_idx = grid.periodicIndex(ix_glb, iy_glb);
+          gidx_t master_idx       = local_orca.master_global_index( i, j );
+          const auto master_global_ij = local_orca.master_global_ij( i, j );
+          ASSERT_MSG(master_global_ij.i < grid.nx(),
+             std::string("master_global_ij.i ") + std::to_string(master_global_ij.i)
+             + " grid.nx() " + std::to_string(grid.nx()) );
+          ASSERT_MSG(master_global_ij.j < grid.ny(),
+             std::string("master_global_ij.j ") + std::to_string(master_global_ij.j)
+             + " grid.ny() " + std::to_string(grid.ny()) );
+          ASSERT_MSG(master_global_ij.i >= -1,
+             std::string("master_global_ij.i ") + std::to_string(master_global_ij.i));
+          ASSERT_MSG(master_global_ij.j >= -1,
+             std::string("master_global_ij.j ") + std::to_string(master_global_ij.j));
+          const auto grid_xy        = local_orca.grid_xy( i, j );
+          const auto normed_grid_xy = local_orca.normalised_grid_xy( i, j );
+
+          if (halo == 0) {
+            const auto ij_glb = local_orca.global_ij( i, j );
+            const auto ij_glb_haloed = local_orca.orca_haloed_global_grid_ij( i, j );
+            ASSERT_MSG(ij_glb.i == ij_glb_haloed.i,
+               std::string("ij_glb.i != ij_glb_haloed.i ") + std::to_string(ij_glb.i)
+               + std::string(" != ") + std::to_string(ij_glb_haloed.i));
+            ASSERT_MSG(ij_glb.j == ij_glb_haloed.j,
+               std::string("ij_glb.j != ij_glb_haloed.j ") + std::to_string(ij_glb.j)
+               + std::string(" != ") + std::to_string(ij_glb_haloed.j));
+          }
+
+          if (local_orca.parts.at(ii) == cfg.mypart) {
+            this_partition.emplace_back(true);
+          } else {
+            this_partition.emplace_back(false);
+          }
+          const auto water = local_orca.water(i, j);
+          const auto halo = local_orca.halo.at(ii);
+          int flags = 0;
+          util::detail::BitflagsView<int> flags_view(flags);
+          local_orca.flags( i, j, flags_view );
+
+          // check points in the orca halo behave as expected.
+          if ((ix_glb > grid.nx()) ||
+              (ix_glb > grid.nx()/2 && iy_glb > grid.ny())) {
+            //std::cout << "ix_glb, iy_glb : " << ix_glb << ", " << iy_glb << " is_ghost "  << local_orca.is_ghost.at(ii)
+            //          << "local_orca.master_global_index(i, j) != local_orca.orca_haloed_global_grid_index(i,j)"
+            //          << local_orca.master_global_index(i, j) << " != " << local_orca.orca_haloed_global_grid_index(i,j)
+            //          << " -- " << grid.ghost( ix_glb, iy_glb ) << std::endl;
+            // this grid point should be a ghost point.
+            if ( iy_glb > 0 or ix_glb < 0 ) {
+              EXPECT(local_orca.is_ghost_including_orca_halo.at(ii) >= grid.ghost( ix_glb, iy_glb ));
+            }
+            // this grid point should not be a master grid point.
+            //EXPECT(local_orca.master_global_index(i, j)
+            //       != local_orca.orca_haloed_global_grid_index(i,j));
+          }
+        }
+      }
+      int total_is_node =
+          std::count(local_orca.is_node.begin(), local_orca.is_node.end(), true);
+      int total_is_ghost =
+          std::count(local_orca.is_ghost.begin(), local_orca.is_ghost.end(), true);
+      EXPECT(total_is_node <= indices.size());
+      if (distributionName == "serial")
+        EXPECT(local_orca.nb_used_nodes() == local_orca.nx() * local_orca.ny());
+      EXPECT(total_is_ghost >= local_orca.nb_used_ghost_nodes());
+      EXPECT(indices.size() == local_orca.nx() * local_orca.ny());
+
+      {
+        // diagnostics
+        auto total_on_partition =
+            std::count(this_partition.begin(), this_partition.end(), true);
+        auto not_on_partition =
+            std::count(this_partition.begin(), this_partition.end(), false);
+
+        std::cout << "[" << cfg.mypart << "] grid.haloWest() " << grid.haloWest()
+                  << " grid.haloEast() " << grid.haloEast()
+                  << " grid.haloNorth() " << grid.haloNorth()
+                  << " grid.haloSouth() " << grid.haloSouth()
+                  << std::endl;
+        std::cout << "[" << cfg.mypart << "]"
+                  << " ix_orca_min " << local_orca.ix_min() << " ix_orca_max "
+                  << local_orca.ix_max() << " iy_orca_min " << local_orca.iy_min()
+                  << " iy_orca_max " << local_orca.iy_max() << " indices.size() "
+                  << indices.size() << " nx * ny " << local_orca.nx() << " * " << local_orca.ny()
+                  << " " << local_orca.nx() * local_orca.ny()
+                  << " number on this partition " << total_on_partition
+                  << " number not on partition " << not_on_partition << std::endl;
+
+        output::Gmsh gmsh(std::string("surroundingRect") +
+                              std::to_string(cfg.nparts) + "_" + gridname + "_" +
+                              distributionName + "_" + std::to_string(halo) +
+                              ".msh",
+                          Config("coordinates", "xy") | Config("info", true));
+      }
+
+      const idx_t cell_width = 1;
+      if (cfg.nparts == 2) {
+        if (cfg.mypart == 0) {
+          EXPECT(local_orca.iy_min() == -grid.haloSouth());
+          EXPECT(local_orca.iy_max() == grid.ny() + grid.haloNorth() - 1 + halo);
+          EXPECT(local_orca.ix_min() == -grid.haloWest() - halo);
+          EXPECT(local_orca.ix_max() == 90 + halo);
+          EXPECT(local_orca.nx() == 91 + grid.haloWest() + 2*halo);
+          EXPECT(local_orca.ny() == grid.ny() + grid.haloSouth() + grid.haloNorth() + halo);
+        }
+        if (cfg.mypart == 1) {
+          EXPECT(local_orca.iy_min() == -grid.haloSouth());
+          EXPECT(local_orca.iy_max() == grid.ny() + grid.haloNorth() - 1 + halo);
+          EXPECT(local_orca.ix_min() == 90 - halo);
+          EXPECT(local_orca.ix_max() == grid.nx() + grid.haloEast() - 1 + halo);
+          EXPECT(local_orca.nx() == 90 + grid.haloEast() + 2*halo);
+          EXPECT(local_orca.ny() == grid.ny() + grid.haloSouth() + grid.haloNorth() + halo);
+        }
+      }
+    }
+  }
+}
+
+} // namespace test
+} // namespace atlas
+
+int main(int argc, char **argv) { return atlas::test::run(argc, argv); }

--- a/src/tests/test_orca_local_grid.cc
+++ b/src/tests/test_orca_local_grid.cc
@@ -72,10 +72,6 @@ CASE("test surrounding local_orca ") {
       cfg.nx_glb = grid.nx();
       cfg.ny_glb = grid.ny();
       orca::meshgenerator::SurroundingRectangle rectangle(distribution, cfg);
-      std::cout << "[" << cfg.mypart << "] rectangle.ix_min " <<  rectangle.ix_min()
-                << " rectangle.ix_max " <<  rectangle.ix_max()
-                << " rectangle.iy_min " <<  rectangle.iy_min()
-                << " rectangle.iy_max " <<  rectangle.iy_max() << std::endl;
       orca::meshgenerator::LocalOrcaGrid local_orca(grid, rectangle);
 
       std::vector<idx_t> indices;
@@ -165,34 +161,6 @@ CASE("test surrounding local_orca ") {
         EXPECT(local_orca.nb_used_nodes() == local_orca.nx() * local_orca.ny());
       EXPECT(total_is_ghost >= local_orca.nb_used_ghost_nodes());
       EXPECT(indices.size() == local_orca.nx() * local_orca.ny());
-
-      {
-        // diagnostics
-        auto total_on_partition =
-            std::count(this_partition.begin(), this_partition.end(), true);
-        auto not_on_partition =
-            std::count(this_partition.begin(), this_partition.end(), false);
-
-        std::cout << "[" << cfg.mypart << "] grid.haloWest() " << grid.haloWest()
-                  << " grid.haloEast() " << grid.haloEast()
-                  << " grid.haloNorth() " << grid.haloNorth()
-                  << " grid.haloSouth() " << grid.haloSouth()
-                  << std::endl;
-        std::cout << "[" << cfg.mypart << "]"
-                  << " ix_orca_min " << local_orca.ix_min() << " ix_orca_max "
-                  << local_orca.ix_max() << " iy_orca_min " << local_orca.iy_min()
-                  << " iy_orca_max " << local_orca.iy_max() << " indices.size() "
-                  << indices.size() << " nx * ny " << local_orca.nx() << " * " << local_orca.ny()
-                  << " " << local_orca.nx() * local_orca.ny()
-                  << " number on this partition " << total_on_partition
-                  << " number not on partition " << not_on_partition << std::endl;
-
-        output::Gmsh gmsh(std::string("surroundingRect") +
-                              std::to_string(cfg.nparts) + "_" + gridname + "_" +
-                              distributionName + "_" + std::to_string(halo) +
-                              ".msh",
-                          Config("coordinates", "xy") | Config("info", true));
-      }
 
       const idx_t cell_width = 1;
       // Values below are for ORCA2_T grid.

--- a/src/tests/test_orca_local_grid.cc
+++ b/src/tests/test_orca_local_grid.cc
@@ -86,13 +86,13 @@ CASE("test surrounding local_orca ") {
         int iy_glb = local_orca.iy_min() + j;
         ASSERT_MSG(iy_glb < (grid.ny() + std::max(grid.haloNorth(), halo + 1)), "iy_glb in range " +
                    std::to_string(j) + " " + std::to_string(local_orca.iy_min()) + " " +
-                   std::to_string(iy_glb) + " " + std::to_string(grid.ny()) + " " + 
+                   std::to_string(iy_glb) + " " + std::to_string(grid.ny()) + " " +
                    std::to_string(grid.haloNorth()) + " " + std::to_string(halo));
         for (uint64_t i = 0; i < local_orca.nx(); i++) {
           int ix_glb = local_orca.ix_min() + i;
           ASSERT_MSG(ix_glb < (grid.nx() + std::max(grid.haloEast(), halo + 1)), "ix_glb in range " +
                      std::to_string(i) + " " + std::to_string(local_orca.ix_min()) + " " +
-                     std::to_string(ix_glb) + " " + std::to_string(grid.nx()) + " " + 
+                     std::to_string(ix_glb) + " " + std::to_string(grid.nx()) + " " +
                      std::to_string(grid.haloEast()) + " " + std::to_string(halo));
           auto ii = local_orca.index(i, j);
           indices.emplace_back(ii);
@@ -101,11 +101,11 @@ CASE("test surrounding local_orca ") {
           const auto ohgg_ij = local_orca.orca_haloed_global_grid_ij( i, j );
           ASSERT_MSG(ohgg_ij.i < grid.nx() + grid.haloEast(),
              std::string("ohgg_ij.i ") + std::to_string(ohgg_ij.i)
-             + std::string(" grid.nx()) ") + std::to_string(grid.nx()) 
+             + std::string(" grid.nx()) ") + std::to_string(grid.nx())
              + std::string(" grid.haloEast() ") + std::to_string(grid.haloEast()) );
           ASSERT_MSG(ohgg_ij.j < grid.ny() + grid.haloNorth(),
              std::string("ohgg_ij.j ") + std::to_string(ohgg_ij.j)
-             + std::string(" grid.ny() ") + std::to_string(grid.ny()) 
+             + std::string(" grid.ny() ") + std::to_string(grid.ny())
              + std::string(" grid.haloNorth() ") + std::to_string(grid.haloNorth()) );
           ASSERT_MSG(ohgg_ij.i >= -grid.haloWest(),
              std::string("ohgg_ij.i ") + std::to_string(ohgg_ij.i)
@@ -144,7 +144,7 @@ CASE("test surrounding local_orca ") {
               ((ix_glb >= grid.nx()) || (ix_glb > grid.nx()/2 && iy_glb > grid.ny()))) {
             // this grid point should be a ghost point.
             if ( ohgg_ij.j >= 0 or ohgg_ij.i < 0 or ohgg_ij.i >= grid.nx() ) {
-              EXPECT(local_orca.is_ghost_including_orca_halo.at(ii) 
+              EXPECT(local_orca.is_ghost_including_orca_halo.at(ii)
                      >= grid.ghost( ohgg_ij.i, ohgg_ij.j ));
             }
             if ( (ix_glb >= -grid.haloWest()) && (ix_glb < grid.nx() + grid.haloEast()) &&

--- a/src/tests/test_orca_mesh.cc
+++ b/src/tests/test_orca_mesh.cc
@@ -72,7 +72,7 @@ CASE( "test orca mesh halo" ) {
     auto gridnames = std::vector<std::string>{
         "ORCA2_T",   //
         "eORCA1_T",  //
-        //"eORCA025_T",  //
+        "eORCA025_T",  //
     };
     for ( auto gridname : gridnames ) {
         SECTION( gridname ) {

--- a/src/tests/test_orca_mesh.cc
+++ b/src/tests/test_orca_mesh.cc
@@ -72,7 +72,7 @@ CASE( "test orca mesh halo" ) {
     auto gridnames = std::vector<std::string>{
         "ORCA2_T",   //
         "eORCA1_T",  //
-        "eORCA025_T",  //
+        // "eORCA025_T",  //
     };
     for ( auto gridname : gridnames ) {
         SECTION( gridname ) {

--- a/src/tests/test_orca_mesh_boundaries.cc
+++ b/src/tests/test_orca_mesh_boundaries.cc
@@ -60,7 +60,7 @@ CASE( "test haloExchange " ) {
 
     for ( auto distributionName : distributionNames ) {
         for ( auto gridname : gridnames ) {
-            for ( int64_t halo = 0; halo < 2; ++halo ) {
+            for ( int64_t halo = 0; halo <= 2; ++halo ) {
                 if ( ((distributionName == "serial") || (mpi::size() == 1)) && (halo != 0) )
                   continue;
                 SECTION( gridname + "_" + distributionName + "_halo" + std::to_string(halo) ) {

--- a/src/tests/test_orca_mesh_boundaries.cc
+++ b/src/tests/test_orca_mesh_boundaries.cc
@@ -44,12 +44,14 @@ CASE( "test haloExchange " ) {
         "ORCA2_U",   //
         "ORCA2_V",   //
         "eORCA1_T",  //
-                     //        "eORCA025_T",  //
-                     //        "eORCA12_T",  //
+        "eORCA025_T",  //
+        "eORCA12_T",  //
     };
     auto distributionNames = std::vector<std::string>{
-        "serial", "checkerboard",
-        "equal_regions",  //
+      "serial",
+      "checkerboard",
+      "equal_regions",
+      // "equal_area",
     };
 
     auto rollup_plus = []( const double lon, const double lat ) {
@@ -59,14 +61,17 @@ CASE( "test haloExchange " ) {
     for ( auto distributionName : distributionNames ) {
         for ( auto gridname : gridnames ) {
             for ( int64_t halo = 0; halo < 1; ++halo ) {
-                SECTION( gridname + "_" + distributionName + "_halo" + std::to_string( halo ) ) {
-                    auto grid           = Grid( gridname );
-                    auto meshgen_config = grid.meshgenerator() | option::halo( halo );
-                    atlas::MeshGenerator meshgen( meshgen_config );
+                if ( distributionName == "serial" && halo != 0 )
+                  continue;
+                SECTION( gridname + "_" + distributionName + "_halo" + std::to_string(halo) ) {
+                    auto grid = Grid(gridname);
+                    auto meshgen_config = grid.meshgenerator() | option::halo(halo);
+                    atlas::MeshGenerator meshgen(meshgen_config);
                     auto partitioner_config = grid.partitioner();
                     partitioner_config.set( "type", distributionName );
                     auto partitioner = grid::Partitioner( partitioner_config );
                     auto mesh        = meshgen.generate( grid, partitioner );
+                    std::cout << "mesh generator finished " << std::endl;
                     REQUIRE( mesh.grid() );
                     EXPECT( mesh.grid().name() == gridname );
                     idx_t count{ 0 };
@@ -83,6 +88,7 @@ CASE( "test haloExchange " ) {
                     auto f2           = array::make_view<double, 1>( field2 );
                     const auto ghosts = atlas::array::make_view<int32_t, 1>( mesh.nodes().ghost() );
                     const auto lonlat = array::make_view<double, 2>( mesh.nodes().lonlat() );
+                    std::cout << "begin loop over mesh nodes " << std::endl;
                     for ( idx_t jnode = 0; jnode < mesh.nodes().size(); ++jnode ) {
                         if ( ghosts( jnode ) ) {
                             f( jnode ) = 0;
@@ -106,6 +112,7 @@ CASE( "test haloExchange " ) {
                     const auto ij = array::make_view<idx_t, 2>( mesh.nodes().field( "ij" ) );
 
                     double sumSquares{ 0.0 };
+                    int halocount = 0;
                     for ( idx_t jnode = 0; jnode < mesh.nodes().size(); ++jnode ) {
                         f2( jnode )      = 0;
                         const double lon = lonlat( jnode, 0 );
@@ -121,18 +128,25 @@ CASE( "test haloExchange " ) {
                                       << " lon " << lonlat( jnode, 0 ) << " lat " << lonlat( jnode, 1 ) << std::endl;
                             f2( jnode ) = 1;
                         }
+                        if (halos(jnode) > 0) {
+                          std::cout << "[" << mpi::rank() << "] i " << ij(jnode, 0) << " j " << ij(jnode, 1)
+                                    << " halo(" << jnode << ") " << halos(jnode)
+                                    << " ghost " << ghosts(jnode) << " master_global_index " << master_glb_idxs(jnode)
+                                    << " lon " << lonlat(jnode, 0) << " lat " << lonlat(jnode, 1) << std::endl;
+                          halocount++;
+                        }
                     }
-                    if ( count != 0 ) {
-                        Log::info() << "count nonzero and norm of differences is: " << std::sqrt( sumSquares )
-                                    << std::endl;
+                    //if ( count != 0 ) {
+                        Log::info() << "count nonzero and norm of differences is: " << std::sqrt(sumSquares) << std::endl;
+                        Log::info() << "count nonzero halo points: " << halocount << std::endl;
                         Log::info() << "To diagnose problem, uncomment mesh writing here: " << Here() << std::endl;
-                        // output::Gmsh gmsh(
-                        //     std::string("haloExchange_")+gridname+"_"+distributionName+"_"+std::to_string(halo)+".msh",
-                        //     Config("coordinates","ij")|Config("info",true));
-                        // gmsh.write(mesh);
-                        // gmsh.write(field);
-                        // gmsh.write(field2);
-                    }
+                        //output::Gmsh gmsh(
+                        //    std::string("haloExchange_")+gridname+"_"+distributionName+"_"+std::to_string(halo)+".msh",
+                        //    Config("coordinates","ij")|Config("info",true));
+                        //gmsh.write(mesh);
+                        //gmsh.write(field);
+                        //gmsh.write(field2);
+                    //}
                     EXPECT_EQ( count, 0 );
                 }
             }

--- a/src/tests/test_orca_mesh_boundaries.cc
+++ b/src/tests/test_orca_mesh_boundaries.cc
@@ -60,8 +60,8 @@ CASE( "test haloExchange " ) {
 
     for ( auto distributionName : distributionNames ) {
         for ( auto gridname : gridnames ) {
-            for ( int64_t halo = 0; halo < 1; ++halo ) {
-                if ( distributionName == "serial" && halo != 0 )
+            for ( int64_t halo = 0; halo < 2; ++halo ) {
+                if ( ((distributionName == "serial") || (mpi::size() == 1)) && (halo != 0) )
                   continue;
                 SECTION( gridname + "_" + distributionName + "_halo" + std::to_string(halo) ) {
                     auto grid = Grid(gridname);

--- a/src/tests/test_orca_mesh_boundaries.cc
+++ b/src/tests/test_orca_mesh_boundaries.cc
@@ -71,7 +71,7 @@ CASE( "test haloExchange " ) {
                     partitioner_config.set( "type", distributionName );
                     auto partitioner = grid::Partitioner( partitioner_config );
                     auto mesh        = meshgen.generate( grid, partitioner );
-                    std::cout << "mesh generator finished " << std::endl;
+                    Log::info() << "mesh generator finished " << std::endl;
                     REQUIRE( mesh.grid() );
                     EXPECT( mesh.grid().name() == gridname );
                     idx_t count{ 0 };
@@ -88,7 +88,7 @@ CASE( "test haloExchange " ) {
                     auto f2           = array::make_view<double, 1>( field2 );
                     const auto ghosts = atlas::array::make_view<int32_t, 1>( mesh.nodes().ghost() );
                     const auto lonlat = array::make_view<double, 2>( mesh.nodes().lonlat() );
-                    std::cout << "begin loop over mesh nodes " << std::endl;
+                    Log::info() << "begin loop over mesh nodes " << std::endl;
                     for ( idx_t jnode = 0; jnode < mesh.nodes().size(); ++jnode ) {
                         if ( ghosts( jnode ) ) {
                             f( jnode ) = 0;
@@ -122,17 +122,22 @@ CASE( "test haloExchange " ) {
                             sumSquares += std::pow( std::abs( f( jnode ) - rollup_plus( lon, lat ) ), 2 );
                             ++count;
                         }
+                        bool DEBUGGING = false;
                         if ( remote_idxs( jnode ) < 0 ) {
-                            std::cout << "[" << mpi::rank() << "] remote_idx < 0 " << jnode << " : ghost "
-                                      << ghosts( jnode ) << " master_global_index " << master_glb_idxs( jnode )
-                                      << " lon " << lonlat( jnode, 0 ) << " lat " << lonlat( jnode, 1 ) << std::endl;
+                            if( DEBUGGING ) {
+                                std::cout << "[" << mpi::rank() << "] remote_idx < 0 " << jnode << " : ghost "
+                                        << ghosts( jnode ) << " master_global_index " << master_glb_idxs( jnode )
+                                        << " lon " << lonlat( jnode, 0 ) << " lat " << lonlat( jnode, 1 ) << std::endl;
+                            }
                             f2( jnode ) = 1;
                         }
                         if (halos(jnode) > 0) {
-                          std::cout << "[" << mpi::rank() << "] i " << ij(jnode, 0) << " j " << ij(jnode, 1)
-                                    << " halo(" << jnode << ") " << halos(jnode)
-                                    << " ghost " << ghosts(jnode) << " master_global_index " << master_glb_idxs(jnode)
-                                    << " lon " << lonlat(jnode, 0) << " lat " << lonlat(jnode, 1) << std::endl;
+                            if( DEBUGGING ) {
+                                std::cout << "[" << mpi::rank() << "] i " << ij(jnode, 0) << " j " << ij(jnode, 1)
+                                          << " halo(" << jnode << ") " << halos(jnode)
+                                          << " ghost " << ghosts(jnode) << " master_global_index " << master_glb_idxs(jnode)
+                                          << " lon " << lonlat(jnode, 0) << " lat " << lonlat(jnode, 1) << std::endl;
+                            }
                           halocount++;
                         }
                     }

--- a/src/tests/test_orca_mesh_boundaries.cc
+++ b/src/tests/test_orca_mesh_boundaries.cc
@@ -44,8 +44,8 @@ CASE( "test haloExchange " ) {
         "ORCA2_U",   //
         "ORCA2_V",   //
         "eORCA1_T",  //
-        "eORCA025_T",  //
-        "eORCA12_T",  //
+        // "eORCA025_T",  //
+        // "eORCA12_T",  //
     };
     auto distributionNames = std::vector<std::string>{
       "serial",

--- a/src/tests/test_orca_polygon_locator.cc
+++ b/src/tests/test_orca_polygon_locator.cc
@@ -36,7 +36,7 @@ CASE( "test orca polygon locator" ) {
         "ORCA2_T",     //
         "eORCA1_T",    //
         "eORCA025_T",  //
-        // "eORCA12_T",  //
+        "eORCA12_T",  //
     };
 
     std::string grid_resource = eckit::Resource<std::string>( "--grid", "" );

--- a/src/tests/test_orca_polygon_locator.cc
+++ b/src/tests/test_orca_polygon_locator.cc
@@ -35,8 +35,8 @@ CASE( "test orca polygon locator" ) {
     auto gridnames = std::vector<std::string>{
         "ORCA2_T",     //
         "eORCA1_T",    //
-        "eORCA025_T",  //
-        "eORCA12_T",  //
+        // "eORCA025_T",  //
+        // "eORCA12_T",  //
     };
 
     std::string grid_resource = eckit::Resource<std::string>( "--grid", "" );

--- a/src/tests/test_orca_surrounding_rectangle.cc
+++ b/src/tests/test_orca_surrounding_rectangle.cc
@@ -1,0 +1,245 @@
+/*
+ * (C) Copyright 2021- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include <algorithm>
+#include <sstream>
+#include <fstream>
+#include <iomanip>
+
+#include "atlas-orca/meshgenerator/SurroundingRectangle.h"
+#include "atlas/functionspace/NodeColumns.h"
+#include "atlas/grid.h"
+#include "atlas/grid/Spacing.h"
+#include "atlas/grid/StructuredGrid.h"
+#include "atlas/mesh.h"
+#include "atlas/meshgenerator.h"
+#include "atlas/output/Gmsh.h"
+#include "atlas/parallel/mpi/mpi.h"
+#include "atlas/util/Config.h"
+#include "atlas/util/function/VortexRollup.h"
+#include "atlas/util/Point.h"
+
+#include "atlas-orca/grid/OrcaGrid.h"
+#include "atlas-orca/util/PointIJ.h"
+
+#include "tests/AtlasTestEnvironment.h"
+
+using Grid = atlas::Grid;
+using Config = atlas::util::Config;
+
+namespace atlas {
+namespace test {
+
+int wrap( idx_t value, idx_t lower, idx_t upper ) {
+  // wrap around coordinate system when out of bounds
+  const idx_t width = upper - lower;
+  if (value < lower) {
+    return wrap(value + width, lower, upper);
+  }
+  if (value > upper) {
+    return wrap(value - width, lower, upper);
+  }
+  return value;
+}
+
+//-----------------------------------------------------------------------------
+
+CASE("test surrounding rectangle ") {
+  std::string gridname = "ORCA2_T";
+  std::string distributionName = "checkerboard";
+
+  auto rollup_plus = [](const double lon, const double lat) {
+    return 1 + util::function::vortex_rollup(lon, lat, 0.0);
+  };
+
+  for (int halo = 0; halo < 3; ++halo) {
+    SECTION(gridname + "_" + distributionName + "_halo" + std::to_string(halo)) {
+      auto grid = OrcaGrid(gridname);
+      auto partitioner_config = Config();
+      partitioner_config.set("type", distributionName);
+      auto partitioner = grid::Partitioner(partitioner_config);
+      StructuredGrid::YSpace yspace{grid::LinearSpacing{
+          {-80., 90.}, grid.ny(), true}};
+      StructuredGrid::XSpace xspace{
+          grid::LinearSpacing{{0., 360.}, grid.nx(), false}};
+      StructuredGrid regular_grid{xspace, yspace};
+      auto distribution = grid::Distribution(regular_grid, partitioner);
+
+      orca::meshgenerator::SurroundingRectangle::Configuration cfg;
+      cfg.mypart = mpi::rank();
+      cfg.nparts = mpi::size();
+      cfg.halosize = halo;
+      cfg.nx_glb = grid.nx();
+      cfg.ny_glb = grid.ny();
+      std::cout << "[" << cfg.mypart << "] " << regular_grid.type() << std::endl;
+
+      const idx_t cell_width = 1;
+      if (regular_grid.ny() != grid.ny()) {
+        std::cout << regular_grid.ny() << " != " << grid.ny() << std::endl;
+      }
+      EXPECT(regular_grid.ny() == grid.ny());
+      for (idx_t ix = 0; ix < grid.ny(); ++ix) {
+        if (regular_grid.nx(ix)!= grid.nx()) {
+          std::cout << regular_grid.nx(ix)<< " != " << grid.nx() << std::endl;
+        }
+        EXPECT(regular_grid.nx(ix) == grid.nx());
+      }
+      std::cout << " last index? " << regular_grid.index(grid.nx()-1, grid.ny()-1) << std::endl;
+
+      orca::meshgenerator::SurroundingRectangle rectangle(distribution, cfg);
+
+      auto regular_mesh = atlas::Mesh(regular_grid, partitioner);
+
+      auto fview_lonlat =
+          array::make_view<double, 2>(regular_mesh.nodes().lonlat());
+      auto fview_glb_idx =
+          array::make_view<gidx_t, 1>(regular_mesh.nodes().global_index());
+
+      std::ofstream ghostFile(std::string("is_ghost_") + distribution.type() + "-"
+          + std::to_string(cfg.halosize) + "_p"
+          + std::to_string(cfg.mypart) + ".csv");
+
+      std::ofstream haloFile(std::string("is_halo_") + distribution.type() + "-"
+          + std::to_string(cfg.halosize) + "_p"
+          + std::to_string(cfg.mypart) + ".csv");
+
+      std::ofstream partFile(std::string("parts_") + distribution.type() + "-"
+          + std::to_string(cfg.halosize) + "_p"
+          + std::to_string(cfg.mypart) + ".csv");
+
+      functionspace::NodeColumns regular_fs(regular_mesh);
+      std::vector<int> indices;
+      std::vector<bool> this_partition;
+      for (uint64_t j = 0; j < rectangle.ny(); j++) {
+        int iy_glb = rectangle.iy_min() + j;
+        EXPECT(iy_glb < grid.ny() + cell_width + 2*halo);
+        for (uint64_t i = 0; i < rectangle.nx(); i++) {
+          int ix_glb = rectangle.ix_min() + i;
+          EXPECT(ix_glb < grid.nx() + cell_width + 2*halo);
+          auto ii = rectangle.index(i, j);
+          indices.emplace_back(ii);
+          atlas::orca::PointIJ ij = rectangle.global_periodic_ij(ix_glb, iy_glb);
+          ATLAS_ASSERT(ij.i < cfg.nx_glb);
+          ATLAS_ASSERT(ij.j < cfg.ny_glb);
+
+          haloFile  << i << ", " << j << ", " << rectangle.halo.at(ii) << std::endl;
+          ghostFile << i << ", " << j << ", " << rectangle.is_ghost.at(ii) << std::endl;
+          partFile << i << ", " << j << ", " << rectangle.parts.at(ii) << std::endl;
+
+          idx_t reg_grid_glb_idx  = regular_grid.index(ix_glb, iy_glb);
+          idx_t orca_grid_glb_idx = grid.periodicIndex(ix_glb, iy_glb);
+          idx_t reg_grid_remote_idx = 0;
+          while(reg_grid_remote_idx < fview_glb_idx.size()) {
+            if (reg_grid_glb_idx == fview_glb_idx(reg_grid_remote_idx))
+              break;
+            ++reg_grid_remote_idx;
+          }
+
+          if (rectangle.partition(ix_glb, iy_glb) == cfg.mypart) {
+            this_partition.emplace_back(true);
+          } else {
+            this_partition.emplace_back(false);
+          }
+
+          // If it is not a ghost node, it must be a node, however some ghost
+          // nodes are also nodes.
+          // TODO: Understand what is going on with this!
+          //if (!rectangle.is_ghost.at(ii)) {
+          //    std::cout << "[" << cfg.mypart << "] i " << i << " j " << j << " ii " << ii << std::endl;
+          //}
+        }
+      }
+      haloFile.close();
+      ghostFile.close();
+      partFile.close();
+
+      int total_is_ghost =
+          std::count(rectangle.is_ghost.begin(), rectangle.is_ghost.end(), true);
+
+      EXPECT(indices.size() == rectangle.nx() * rectangle.ny());
+
+      {
+        // diagnostics
+        auto total_on_partition =
+            std::count(this_partition.begin(), this_partition.end(), true);
+        auto not_on_partition =
+            std::count(this_partition.begin(), this_partition.end(), false);
+
+        std::cout << "[" << cfg.mypart << "] grid.haloWest() " << grid.haloWest()
+                  << " grid.haloEast() " << grid.haloEast()
+                  << " grid.haloNorth() " << grid.haloNorth()
+                  << " grid.haloSouth() " << grid.haloSouth()
+                  << std::endl;
+        std::cout << "[" << cfg.mypart << "]"
+                  << " ix_min " << rectangle.ix_min() << " ix_max "
+                  << rectangle.ix_max() << " iy_min " << rectangle.iy_min()
+                  << " iy_max " << rectangle.iy_max() << " indices.size() "
+                  << indices.size() << " nx*ny " << rectangle.nx() * rectangle.ny()
+                  << " number on this partition " << total_on_partition
+                  << " number not on partition " << not_on_partition << std::endl;
+
+        //output::Gmsh gmsh(std::string("surroundingRect") +
+        //                      std::to_string(cfg.nparts) + "_" + gridname + "_" +
+        //                      distributionName + "_" + std::to_string(halo) +
+        //                      ".msh",
+        //                  Config("coordinates", "xy") | Config("info", true));
+        //gmsh.write(regular_mesh);
+      }
+
+      std::cout << "(iy_min, iy_max) (" << rectangle.iy_min() << ", " << rectangle.iy_max() << ") "
+                << "(ix_min, ix_max) (" << rectangle.ix_min() << ", " << rectangle.ix_max() << ") " << std::endl;
+      if (cfg.nparts == 2) {
+        if (cfg.mypart == 0) {
+          EXPECT(rectangle.iy_min() == 0 - halo);
+          EXPECT(rectangle.iy_max() == 147 + halo);
+          EXPECT(rectangle.ix_min() == 0 - halo);
+          EXPECT(rectangle.ix_max() == 90 + halo);
+        }
+        if (cfg.mypart == 1) {
+          EXPECT(rectangle.iy_min() == 0 - halo);
+          EXPECT(rectangle.iy_max() == 147 + halo);
+          EXPECT(rectangle.ix_min() == 90 - halo);
+          EXPECT(rectangle.ix_max() == 180 + halo);
+        }
+      }
+      if (cfg.nparts == 4) {
+        if (cfg.mypart == 0) {
+          EXPECT(rectangle.iy_min() == 0 - halo);
+          EXPECT(rectangle.iy_max() == 74 + halo);
+          EXPECT(rectangle.ix_min() == 0 - halo);
+          EXPECT(rectangle.ix_max() == 90 + halo);
+        }
+        if (cfg.mypart == 1) {
+          EXPECT(rectangle.iy_min() == 0 - halo);
+          EXPECT(rectangle.iy_max() == 74 + halo);
+          EXPECT(rectangle.ix_min() == 89 - halo);
+          EXPECT(rectangle.ix_max() == 180 + halo);
+        }
+        if (cfg.mypart == 2) {
+          EXPECT(rectangle.iy_min() == 73 - halo);
+          EXPECT(rectangle.iy_max() == 147 + halo);
+          EXPECT(rectangle.ix_min() == 0 - halo);
+          EXPECT(rectangle.ix_max() == 91 + halo);
+        }
+        if (cfg.mypart == 3) {
+          EXPECT(rectangle.iy_min() == 73 - halo);
+          EXPECT(rectangle.iy_max() == 147 + halo);
+          EXPECT(rectangle.ix_min() == 90 - halo);
+          EXPECT(rectangle.ix_max() == 180 + halo);
+        }
+      }
+    }
+  }
+}
+
+} // namespace test
+} // namespace atlas
+
+int main(int argc, char **argv) { return atlas::test::run(argc, argv); }

--- a/src/tests/test_orca_surrounding_rectangle.cc
+++ b/src/tests/test_orca_surrounding_rectangle.cc
@@ -91,7 +91,6 @@ CASE("test surrounding rectangle ") {
         }
         EXPECT(regular_grid.nx(ix) == grid.nx());
       }
-      std::cout << " last index? " << regular_grid.index(grid.nx()-1, grid.ny()-1) << std::endl;
 
       orca::meshgenerator::SurroundingRectangle rectangle(distribution, cfg);
 
@@ -101,18 +100,6 @@ CASE("test surrounding rectangle ") {
           array::make_view<double, 2>(regular_mesh.nodes().lonlat());
       auto fview_glb_idx =
           array::make_view<gidx_t, 1>(regular_mesh.nodes().global_index());
-
-      std::ofstream ghostFile(std::string("is_ghost_") + distribution.type() + "-"
-          + std::to_string(cfg.halosize) + "_p"
-          + std::to_string(cfg.mypart) + ".csv");
-
-      std::ofstream haloFile(std::string("is_halo_") + distribution.type() + "-"
-          + std::to_string(cfg.halosize) + "_p"
-          + std::to_string(cfg.mypart) + ".csv");
-
-      std::ofstream partFile(std::string("parts_") + distribution.type() + "-"
-          + std::to_string(cfg.halosize) + "_p"
-          + std::to_string(cfg.mypart) + ".csv");
 
       functionspace::NodeColumns regular_fs(regular_mesh);
       std::vector<int> indices;
@@ -129,10 +116,6 @@ CASE("test surrounding rectangle ") {
           ATLAS_ASSERT(ij.i < cfg.nx_glb);
           ATLAS_ASSERT(ij.j < cfg.ny_glb);
 
-          haloFile  << i << ", " << j << ", " << rectangle.halo.at(ii) << std::endl;
-          ghostFile << i << ", " << j << ", " << rectangle.is_ghost.at(ii) << std::endl;
-          partFile << i << ", " << j << ", " << rectangle.parts.at(ii) << std::endl;
-
           idx_t reg_grid_glb_idx  = regular_grid.index(ix_glb, iy_glb);
           idx_t orca_grid_glb_idx = grid.periodicIndex(ix_glb, iy_glb);
           idx_t reg_grid_remote_idx = 0;
@@ -147,18 +130,8 @@ CASE("test surrounding rectangle ") {
           } else {
             this_partition.emplace_back(false);
           }
-
-          // If it is not a ghost node, it must be a node, however some ghost
-          // nodes are also nodes.
-          // TODO: Understand what is going on with this!
-          //if (!rectangle.is_ghost.at(ii)) {
-          //    std::cout << "[" << cfg.mypart << "] i " << i << " j " << j << " ii " << ii << std::endl;
-          //}
         }
       }
-      haloFile.close();
-      ghostFile.close();
-      partFile.close();
 
       int total_is_ghost =
           std::count(rectangle.is_ghost.begin(), rectangle.is_ghost.end(), true);
@@ -171,19 +144,6 @@ CASE("test surrounding rectangle ") {
             std::count(this_partition.begin(), this_partition.end(), true);
         auto not_on_partition =
             std::count(this_partition.begin(), this_partition.end(), false);
-
-        std::cout << "[" << cfg.mypart << "] grid.haloWest() " << grid.haloWest()
-                  << " grid.haloEast() " << grid.haloEast()
-                  << " grid.haloNorth() " << grid.haloNorth()
-                  << " grid.haloSouth() " << grid.haloSouth()
-                  << std::endl;
-        std::cout << "[" << cfg.mypart << "]"
-                  << " ix_min " << rectangle.ix_min() << " ix_max "
-                  << rectangle.ix_max() << " iy_min " << rectangle.iy_min()
-                  << " iy_max " << rectangle.iy_max() << " indices.size() "
-                  << indices.size() << " nx*ny " << rectangle.nx() * rectangle.ny()
-                  << " number on this partition " << total_on_partition
-                  << " number not on partition " << not_on_partition << std::endl;
 
         //output::Gmsh gmsh(std::string("surroundingRect") +
         //                      std::to_string(cfg.nparts) + "_" + gridname + "_" +

--- a/src/tests/test_orca_surrounding_rectangle.cc
+++ b/src/tests/test_orca_surrounding_rectangle.cc
@@ -86,8 +86,8 @@ CASE("test surrounding rectangle ") {
       }
       EXPECT(regular_grid.ny() == grid.ny());
       for (idx_t ix = 0; ix < grid.ny(); ++ix) {
-        if (regular_grid.nx(ix)!= grid.nx()) {
-          std::cout << regular_grid.nx(ix)<< " != " << grid.nx() << std::endl;
+        if (regular_grid.nx(ix) != grid.nx()) {
+          std::cout << regular_grid.nx(ix) << " != " << grid.nx() << std::endl;
         }
         EXPECT(regular_grid.nx(ix) == grid.nx());
       }

--- a/src/tests/test_orca_valid_elements.cc
+++ b/src/tests/test_orca_valid_elements.cc
@@ -39,8 +39,8 @@ namespace atlas::test {
 CASE( "test generate orca mesh" ) {
     std::vector<std::string> gridnames{
         "ORCA2_T", "ORCA2_F", "ORCA2_U", "ORCA2_V", "eORCA1_T", "eORCA1_F", "eORCA1_U", "eORCA1_V",
-        //"ORCA1_T", "ORCA1_F", "ORCA1_U", "ORCA1_V",
-        //"eORCA025_T", "eORCA025_F", "eORCA025_U", "eORCA025_V",
+        "ORCA1_T", "ORCA1_F", "ORCA1_U", "ORCA1_V",
+        "eORCA025_T", "eORCA025_F", "eORCA025_U", "eORCA025_V",
     };
 
     bool gmsh_output          = eckit::Resource<bool>( "--gmsh", false );

--- a/src/tests/test_orca_valid_elements.cc
+++ b/src/tests/test_orca_valid_elements.cc
@@ -76,7 +76,8 @@ CASE( "test generate orca mesh" ) {
                         has_invalid_quads = true;
                         Log::info() << "Invalid quad [" << elem_glb_idx( e ) << "] : [ " << connectivity( e, 0 ) + 1
                                     << ", " << connectivity( e, 1 ) + 1 << ", " << connectivity( e, 2 ) + 1 << ", "
-                                    << connectivity( e, 3 ) + 1 << " ]" << std::endl;
+                                    << connectivity( e, 3 ) + 1 << " ] at lon/lats: " << pll[0] << " " << pll[1]
+                                    << " " << pll[2] << " " << pll[3] << std::endl;
                     }
                 }
             }

--- a/src/tests/test_orca_valid_elements.cc
+++ b/src/tests/test_orca_valid_elements.cc
@@ -40,7 +40,7 @@ CASE( "test generate orca mesh" ) {
     std::vector<std::string> gridnames{
         "ORCA2_T", "ORCA2_F", "ORCA2_U", "ORCA2_V", "eORCA1_T", "eORCA1_F", "eORCA1_U", "eORCA1_V",
         "ORCA1_T", "ORCA1_F", "ORCA1_U", "ORCA1_V",
-        "eORCA025_T", "eORCA025_F", "eORCA025_U", "eORCA025_V",
+        // "eORCA025_T", "eORCA025_F", "eORCA025_U", "eORCA025_V",
     };
 
     bool gmsh_output          = eckit::Resource<bool>( "--gmsh", false );


### PR DESCRIPTION
## Description

Split the mesh partitioner into components:
 1.	Generation of the orca global grid (blue box). This is already performed by the OrcaGrid object.
 2.	Generation of the matching global regular lat-lon grid (orange box). This is a simple atlas RegularLonLatGrid structure. This is partitioned by the chosen partitioner to generate a distribution, which we use to determine the partition of each node in subsequent steps
 3.	A local `SurroundingRectangle` (better name might be LocalLonLatGrid, green box) that surrounds the points held by this partition.
 4.	A `LocalOrcaGrid` object that includes any orca periodic points at the edges of the domain owned by the partition.

![image](https://github.com/ecmwf/atlas-orca/assets/14909402/8a249344-5cbe-48e3-ad54-bd6d59ffd289)

This allows us to set the halo at the generation of the surrounding rectangle, and separate out the logic to handle the strangeness of the problems at the orca grid edge.

Note, there were some strange rogue points in the lower portion of the grid that were not seemingly correctly marked as ghost points. This has had no impact to correct, other than it affects our calculation of field norms in orca-jedi.

## Issues 

- ecmwf/atlas-orca/issues/19

## Acceptance criteria

  * All ctests pass
  * halo = 1 configuration of JEDI framework executable properly locates observations on the correct partition.
  * performance after the change is comparable with performance before the change.

## Testing

  * ctests added to cover the components
  * Integration testing as part of [orca-jedi ](https://github.com/MetOffice/orca-jedi/pull/92)
  * Regression testing as part of a full comparison workflow at the Met Office via [jjdocs change](https://github.com/MetOffice/jjdocs/pull/167)