### PR TITLE
Migrate from Library to LibraryManager for list/lookup/exists

### DIFF
--- a/src/tests/AtlasTestEnvironment.h
+++ b/src/tests/AtlasTestEnvironment.h
@@ -21,6 +21,7 @@
 #include "eckit/config/LibEcKit.h"
 #include "eckit/config/Resource.h"
 #include "eckit/eckit.h"
+#include "eckit/system/LibraryManager.h"
 #include "eckit/log/FileTarget.h"
 #include "eckit/log/PrefixTarget.h"
 #include "eckit/mpi/Comm.h"
@@ -299,8 +300,8 @@ static std::string debug_prefix( const std::string& libname ) {
 }
 
 void debug_addTarget( eckit::LogTarget* target ) {
-    for ( std::string libname : eckit::system::Library::list() ) {
-        const eckit::system::Library& lib = eckit::system::Library::lookup( libname );
+    for ( std::string libname : eckit::system::LibraryManager::list() ) {
+        const eckit::system::Library& lib = eckit::system::LibraryManager::lookup( libname );
         if ( lib.debug() ) {
             lib.debugChannel().addTarget( new eckit::PrefixTarget( debug_prefix( libname ), target ) );
         }
@@ -310,8 +311,8 @@ void debug_addTarget( eckit::LogTarget* target ) {
 }
 
 void debug_setTarget( eckit::LogTarget* target ) {
-    for ( std::string libname : eckit::system::Library::list() ) {
-        const eckit::system::Library& lib = eckit::system::Library::lookup( libname );
+    for ( std::string libname : eckit::system::LibraryManager::list() ) {
+        const eckit::system::Library& lib = eckit::system::LibraryManager::lookup( libname );
         if ( lib.debug() ) {
             lib.debugChannel().setTarget( new eckit::PrefixTarget( debug_prefix( libname ), target ) );
         }
@@ -321,8 +322,8 @@ void debug_setTarget( eckit::LogTarget* target ) {
 }
 
 void debug_reset() {
-    for ( std::string libname : eckit::system::Library::list() ) {
-        const eckit::system::Library& lib = eckit::system::Library::lookup( libname );
+    for ( std::string libname : eckit::system::LibraryManager::list() ) {
+        const eckit::system::Library& lib = eckit::system::LibraryManager::lookup( libname );
         if ( lib.debug() ) {
             lib.debugChannel().reset();
         }

--- a/src/tests/test_orca_plugin.cc
+++ b/src/tests/test_orca_plugin.cc
@@ -8,6 +8,8 @@
  * nor does it submit to any jurisdiction.
  */
 
+#include "eckit/system/LibraryManager.h"
+
 #include "atlas/grid.h"
 #include "atlas/meshgenerator.h"
 
@@ -24,7 +26,7 @@ CASE( "test plugin" ) {
     // ATLAS_PLUGINS_SEARCH_PATHS=<path-to-binary-dir>
     // ATLAS_PLUGINS=orca
 
-    EXPECT( eckit::system::Library::exists( "atlas-orca" ) );
+    EXPECT( eckit::system::LibraryManager::exists( "atlas-orca" ) );
     EXPECT( bool( MeshGenerator( "orca" ) ) );
 }
 


### PR DESCRIPTION
### Description

Library::list(), Library::lookup(), and Library::exists() are superseded by LibraryManager equivalents in eckit. Update all call sites in test infrastructure accordingly.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 